### PR TITLE
Update from deprecated "usbdi.h" to "usb.h"

### DIFF
--- a/drivers/libdrv/dbgcommon.cpp
+++ b/drivers/libdrv/dbgcommon.cpp
@@ -2,7 +2,8 @@
 #include <usbip\proto.h>
 #include <usbip\vhci.h>
 
-#include <usbdi.h>
+#include <usb.h>
+#include <usbioctl.h>
 #include <usbuser.h>
 #include <ntstrsafe.h>
 
@@ -488,7 +489,7 @@ const char *usb_setup_pkt_str(char *buf, size_t len, const void *packet)
 
 const char* usbd_transfer_flags(char *buf, size_t len, ULONG TransferFlags)
 {
-	auto dir = USBD_TRANSFER_DIRECTION(TransferFlags) == USBD_TRANSFER_DIRECTION_OUT ? "OUT" : "IN";
+	auto dir = USBD_TRANSFER_DIRECTION_FLAG(TransferFlags) == USBD_TRANSFER_DIRECTION_OUT ? "OUT" : "IN";
 
 	auto st = RtlStringCbPrintfA(buf, len, "%s%s%s%s", dir,
 					TransferFlags & USBD_SHORT_TRANSFER_OK ? "|SHORT_OK" : "",

--- a/drivers/libdrv/usbd_helper.h
+++ b/drivers/libdrv/usbd_helper.h
@@ -3,7 +3,7 @@
 #include <usbip\proto.h>
 
 #include <ntddk.h>
-#include <usbdi.h>
+#include <usb.h>
 
 struct usbip_iso_packet_descriptor;
 
@@ -20,12 +20,12 @@ UINT32 to_linux_flags(ULONG TransferFlags, bool dir_in);
 
 constexpr auto IsTransferDirectionIn(ULONG TransferFlags)
 {
-	return USBD_TRANSFER_DIRECTION(TransferFlags) == USBD_TRANSFER_DIRECTION_IN;
+	return USBD_TRANSFER_DIRECTION_FLAG(TransferFlags) == USBD_TRANSFER_DIRECTION_IN;
 }
 
 constexpr auto IsTransferDirectionOut(ULONG TransferFlags)
 {
-	return USBD_TRANSFER_DIRECTION(TransferFlags) == USBD_TRANSFER_DIRECTION_OUT;
+	return USBD_TRANSFER_DIRECTION_FLAG(TransferFlags) == USBD_TRANSFER_DIRECTION_OUT;
 }
 
 constexpr auto is_transfer_dir_in(const USB_DEFAULT_PIPE_SETUP_PACKET &r)

--- a/drivers/libdrv/usbdsc.h
+++ b/drivers/libdrv/usbdsc.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ntddk.h>
-#include <usbdi.h>
+#include <usb.h>
 
 namespace usbdlib
 {


### PR DESCRIPTION
usbdi.h has been deprecated, as such the driver should be using the newer "usb.h" and "usbioctl.h" when needed.