### PR TITLE
InnoSetup: install test signing cert for debug builds only

### DIFF
--- a/userspace/innosetup/innosetup.vcxproj
+++ b/userspace/innosetup/innosetup.vcxproj
@@ -65,18 +65,18 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <NMakeBuildCommandLine>$(InnoSetupCompiler) /Ssign_util="signtool.exe $p" /DSolutionDir=$(SolutionDir) /DPlatform=$(Platform) /DConfiguration=$(Configuration) /DExePath=$(SolutionDir)$(Platform)\$(Configuration)\usbip.exe /DGuiExePath=$(SolutionDir)$(Platform)\$(Configuration)\wusbip.exe /DVCToolsRedistInstallDir="$(VCToolsRedistInstallDir)" setup.iss</NMakeBuildCommandLine>
+    <NMakeBuildCommandLine>$(InnoSetupCompiler) /Ssign_util="signtool.exe $p" /DSolutionDir=$(SolutionDir) /DPlatform=$(Platform) /DConfiguration=$(Configuration) /DExePath=$(SolutionDir)$(Platform)\$(Configuration)\usbip.exe /DGuiExePath=$(SolutionDir)$(Platform)\$(Configuration)\wusbip.exe /DVCToolsRedistInstallDir="$(VCToolsRedistInstallDir)" /DTEST_SIGNED_SETUP /DTEST_SIGNED_DRIVERS setup.iss</NMakeBuildCommandLine>
     <NMakeOutput>
     </NMakeOutput>
-    <NMakeReBuildCommandLine>$(InnoSetupCompiler) /Ssign_util="signtool.exe $p" /DSolutionDir=$(SolutionDir) /DPlatform=$(Platform) /DConfiguration=$(Configuration) /DExePath=$(SolutionDir)$(Platform)\$(Configuration)\usbip.exe /DGuiExePath=$(SolutionDir)$(Platform)\$(Configuration)\wusbip.exe /DVCToolsRedistInstallDir="$(VCToolsRedistInstallDir)" setup.iss</NMakeReBuildCommandLine>
+    <NMakeReBuildCommandLine>$(InnoSetupCompiler) /Ssign_util="signtool.exe $p" /DSolutionDir=$(SolutionDir) /DPlatform=$(Platform) /DConfiguration=$(Configuration) /DExePath=$(SolutionDir)$(Platform)\$(Configuration)\usbip.exe /DGuiExePath=$(SolutionDir)$(Platform)\$(Configuration)\wusbip.exe /DVCToolsRedistInstallDir="$(VCToolsRedistInstallDir)" /DTEST_SIGNED_SETUP /DTEST_SIGNED_DRIVERS setup.iss</NMakeReBuildCommandLine>
     <NMakePreprocessorDefinitions>_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <NMakeCleanCommandLine>del /F /Q $(SolutionDir)$(Platform)\$(Configuration)\USBip-*-$(Configuration).exe</NMakeCleanCommandLine>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <NMakeBuildCommandLine>$(InnoSetupCompiler) /Ssign_util="signtool.exe $p" /DSolutionDir=$(SolutionDir) /DPlatform=$(Platform) /DConfiguration=$(Configuration) /DExePath=$(SolutionDir)$(Platform)\$(Configuration)\usbip.exe /DGuiExePath=$(SolutionDir)$(Platform)\$(Configuration)\wusbip.exe /DVCToolsRedistInstallDir="$(VCToolsRedistInstallDir)" setup.iss</NMakeBuildCommandLine>
+    <NMakeBuildCommandLine>$(InnoSetupCompiler) /Ssign_util="signtool.exe $p" /DSolutionDir=$(SolutionDir) /DPlatform=$(Platform) /DConfiguration=$(Configuration) /DExePath=$(SolutionDir)$(Platform)\$(Configuration)\usbip.exe /DGuiExePath=$(SolutionDir)$(Platform)\$(Configuration)\wusbip.exe /DVCToolsRedistInstallDir="$(VCToolsRedistInstallDir)" /DTEST_SIGNED_SETUP /DTEST_SIGNED_DRIVERS setup.iss</NMakeBuildCommandLine>
     <NMakeOutput />
-    <NMakeReBuildCommandLine>$(InnoSetupCompiler) /Ssign_util="signtool.exe $p" /DSolutionDir=$(SolutionDir) /DPlatform=$(Platform) /DConfiguration=$(Configuration) /DExePath=$(SolutionDir)$(Platform)\$(Configuration)\usbip.exe /DGuiExePath=$(SolutionDir)$(Platform)\$(Configuration)\wusbip.exe /DVCToolsRedistInstallDir="$(VCToolsRedistInstallDir)" setup.iss</NMakeReBuildCommandLine>
+    <NMakeReBuildCommandLine>$(InnoSetupCompiler) /Ssign_util="signtool.exe $p" /DSolutionDir=$(SolutionDir) /DPlatform=$(Platform) /DConfiguration=$(Configuration) /DExePath=$(SolutionDir)$(Platform)\$(Configuration)\usbip.exe /DGuiExePath=$(SolutionDir)$(Platform)\$(Configuration)\wusbip.exe /DVCToolsRedistInstallDir="$(VCToolsRedistInstallDir)" /DTEST_SIGNED_SETUP /DTEST_SIGNED_DRIVERS setup.iss</NMakeReBuildCommandLine>
     <NMakePreprocessorDefinitions>_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <NMakeCleanCommandLine>del /F /Q $(SolutionDir)$(Platform)\$(Configuration)\USBip-*-$(Configuration).exe</NMakeCleanCommandLine>

--- a/userspace/innosetup/setup.iss
+++ b/userspace/innosetup/setup.iss
@@ -60,11 +60,9 @@
 #define CertName "USBip"
 #define CertPwd "usbip"
 
-; whether SignTool directive uses the project's test certificate
-#define TEST_SIGNED_SETUP
-
-; whether drivers are signed by the project's test certificate
-#define TEST_SIGNED_DRIVERS
+; To install the test certificate, pass /DTEST_SIGNED_SETUP and/or /DTEST_SIGNED_DRIVERS to iscc:
+;   /DTEST_SIGNED_SETUP   - the setup EXE itself is signed with the test certificate
+;   /DTEST_SIGNED_DRIVERS - the drivers are signed with the test certificate
 
 #define INSTALL_TEST_CERTIFICATE (Defined(TEST_SIGNED_SETUP) || Defined(TEST_SIGNED_DRIVERS))
 


### PR DESCRIPTION
We (and by that I mean [fredemmott](https://github.com/fredemmott)) noticed that the installer comes with the, for nearly 15 year valid, test-signing CA.  
A publicly accessible CA at that.

Release builds won't automatically include the CA anymore  
For debug builds, the behavior is unchanged.