### PR TITLE
Fix Full-Speed bulk device enumeration failure

### DIFF
--- a/drivers/ude/wsk_receive.cpp
+++ b/drivers/ude/wsk_receive.cpp
@@ -166,6 +166,36 @@ PAGED void fix_full_speed_endpoint_interval(_In_ USB_CONFIGURATION_DESCRIPTOR *c
 }
 
 /*
+ * UDE/USBHUB3 internally treats all devices as High-Speed.
+ * Full-Speed bulk endpoints have wMaxPacketSize <= 64, but HS requires 512.
+ * USBHUB3 rejects the configuration descriptor if bulk endpoints don't match HS rules,
+ * causing repeated enumeration failures ("Invalid Configuration Descriptor").
+ *
+ * @see fix_full_speed_endpoint_interval
+ */
+_IRQL_requires_same_
+_IRQL_requires_(PASSIVE_LEVEL)
+PAGED void fix_full_speed_bulk_max_packet_size(_In_ USB_CONFIGURATION_DESCRIPTOR *cd)
+{
+	PAGED_CODE();
+
+	for (auto cur = reinterpret_cast<USB_COMMON_DESCRIPTOR*>(cd);
+	     bool(cur = USBD_ParseDescriptors(cd, cd->wTotalLength, cur, USB_ENDPOINT_DESCRIPTOR_TYPE));
+	     cur = libdrv::next(cur)) {
+
+		auto &e = *reinterpret_cast<USB_ENDPOINT_DESCRIPTOR*>(cur);
+
+		if (usb_endpoint_type(e) == UsbdPipeTypeBulk && e.wMaxPacketSize > 0 && e.wMaxPacketSize <= 64) {
+			auto val = e.wMaxPacketSize;
+			e.wMaxPacketSize = 512;
+
+			TraceDbg("bEndpointAddress %#x, wMaxPacketSize %d (patched to %d, FS bulk -> HS)",
+				  e.bEndpointAddress, val, e.wMaxPacketSize);
+		}
+	}
+}
+
+/*
  * Buffer from the server has no gaps (compacted), SUM(src->actual_length) == actual_length,
  * src->offset is ignored for that reason.
  *
@@ -328,6 +358,9 @@ PAGED void post_control_transfer(_Inout_ device_ctx &dev, _In_ const _URB_CONTRO
 			log(d);
                         if (dev.patch_intvl) {
                                 fix_full_speed_endpoint_interval(&d);
+                        }
+                        if (dev.speed() == USB_SPEED_FULL) {
+                                fix_full_speed_bulk_max_packet_size(&d);
                         }
 		}
 		break;


### PR DESCRIPTION
## What

Full-Speed (12 Mbps) USB devices with bulk endpoints fail to enumerate when attached via USB/IP. Windows shows "Invalid Configuration Descriptor" (Problem Code 43) after 3+ re-enumeration attempts.

This adds `fix_full_speed_bulk_max_packet_size()` which patches bulk endpoint `wMaxPacketSize` from the Full-Speed value (<=64) to the High-Speed required value (512) in the configuration descriptor. Same technique as `fix_full_speed_endpoint_interval()` for isochronous bInterval.

## Why

UDE/USBHUB3 internally treats all devices as High-Speed regardless of `UdecxUsbDeviceInitSetSpeed(UdecxUsbFullSpeed)`. USB 2.0 spec section 5.8.3 says HS bulk must be exactly 512 bytes. USBHUB3 rejects the valid Full-Speed value of 64, triggering `CONFIGURATION_DESCRIPTOR_VALIDATION_FAILURE`.

The WPP trace logs on issue #151 confirm the driver correctly receives `USB_SPEED_FULL` and sets `UdecxUsbFullSpeed`, and all descriptors come through intact from Linux. The failure is purely USBHUB3's descriptor validation applying HS rules.

## Why this is safe

- `CMD_SUBMIT` does not carry `wMaxPacketSize` in the USB/IP protocol header, so the patched value never crosses the wire to Linux
- `TransferBufferLength` in bulk URBs is set by the class driver (WinUSB etc.), not derived from `wMaxPacketSize`
- All actual USB packet splitting happens on the Linux host controller using the physical device's real endpoint descriptor
- `wMaxPacketSize` is not read from the stored endpoint descriptor for any transfer logic in the driver (only `bEndpointAddress`, `bmAttributes`, and `bInterval` are used in `set_cmd_submit_usbip_header`)
- Guarded by `dev.speed() == USB_SPEED_FULL` so High-Speed and Super-Speed devices are unaffected

## Device used for investigation

- CANformance CANTCU (VID 1F00, PID 1318) — Full-Speed, vendor-specific class 0xFF, 2 bulk endpoints (IN+OUT, 64 byte)
- OpenWrt 23.05 server (GL-MT300N-V2, kernel 5.15)
- Windows 11 (26100)
- usbip-win2 v0.9.7.5

Not yet tested with a patched build — I don't have a WDK build environment set up. Would appreciate if you could test this or point me to a test build. Happy to verify on my end with the CANTCU device if you can provide a build.

Should also fix CH340 and CP2102 Full-Speed serial adapters reported in issue #20.

Closes #151