### PR TITLE
ude: fix request lifetime races behind the pool corruption in #181

### DIFF
--- a/drivers/ude/context.h
+++ b/drivers/ude/context.h
@@ -146,6 +146,12 @@ struct device_ctx
         LIST_ENTRY requests; // list head, requests that are waiting for USBIP_RET_SUBMIT from a server
         WDFSPINLOCK requests_lock;
 
+        // Requests whose terminal status is published are completed by request_completion_dpc.
+        // request_completion_dpc_active and this list are protected by requests_lock.
+        LIST_ENTRY request_completions;
+        WDFDPC request_completion_dpc;
+        bool request_completion_dpc_active;
+
         // statistics
         UINT64 sent_requests; // were sent successfully
         UINT64 cancelable_requests; // marked as
@@ -207,9 +213,15 @@ inline auto& get_endpoint(_In_ WDFQUEUE queue)
 struct request_ctx
 {
         LIST_ENTRY entry; // head is device_ctx::requests
+        LIST_ENTRY completion_entry; // head is device_ctx::request_completions
         UDECXUSBENDPOINT endpoint;
         seqnum_t seqnum;
+
+        NTSTATUS completion_status;
         bool cancelable;
+        // committed to completion; stays true while the DPC owns the entry,
+        // reset only when the WDFREQUEST is reused for a new transfer
+        bool completion_queued;
 };
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(request_ctx, get_request_ctx)
 

--- a/drivers/ude/context.h
+++ b/drivers/ude/context.h
@@ -220,6 +220,7 @@ struct request_ctx
         NTSTATUS completion_status;
         bool listed;
         bool cancelable;
+        bool send_pending;
         bool response_in_progress;
         bool terminal;
         // committed to completion; stays true while the DPC owns the entry,

--- a/drivers/ude/context.h
+++ b/drivers/ude/context.h
@@ -146,7 +146,7 @@ struct device_ctx
         LIST_ENTRY requests; // list head, requests that are waiting for USBIP_RET_SUBMIT from a server
         WDFSPINLOCK requests_lock;
 
-        // Requests whose terminal status is published are completed by request_completion_dpc.
+        // Requests whose terminal state is ready are completed by request_completion_dpc.
         // request_completion_dpc_active and this list are protected by requests_lock.
         LIST_ENTRY request_completions;
         WDFDPC request_completion_dpc;
@@ -218,7 +218,10 @@ struct request_ctx
         seqnum_t seqnum;
 
         NTSTATUS completion_status;
+        bool listed;
         bool cancelable;
+        bool response_in_progress;
+        bool terminal;
         // committed to completion; stays true while the DPC owns the entry,
         // reset only when the WDFREQUEST is reused for a new transfer
         bool completion_queued;

--- a/drivers/ude/device.cpp
+++ b/drivers/ude/device.cpp
@@ -144,13 +144,8 @@ _IRQL_requires_same_
 void endpoint_purge(_In_ UDECXUSBENDPOINT endpoint)
 {
         auto &endp = *get_endpoint_ctx(endpoint);
-        auto &dev = *get_device_ctx(endp.device);
 
         TraceDbg("dev %04x, endp %04x, queue %04x", ptr04x(endp.device), ptr04x(endpoint), ptr04x(endp.queue));
-
-        while (auto request = device::remove_request(dev, endpoint)) {
-                device::send_cmd_unlink_and_cancel(endp.device, request);
-        }
 
         auto purge_complete = [] ([[maybe_unused]] auto queue, auto ctx) // EVT_WDF_IO_QUEUE_STATE
         { 

--- a/drivers/ude/device.cpp
+++ b/drivers/ude/device.cpp
@@ -139,6 +139,14 @@ void endpoint_reset(_In_ UDECXUSBENDPOINT endp, _In_ WDFREQUEST request)
         }
 }
 
+/*
+ * WdfIoQueuePurge delivers queued canceled requests to EvtIoCanceledOnQueue and dispatches
+ * EvtRequestCancel for driver-owned cancelable requests. While the purge is in progress,
+ * WdfRequestMarkCancelableEx returns STATUS_CANCELLED for a request whose WskSend has
+ * just completed, which routes it through CMD_UNLINK and the completion DPC as well.
+ * The purge-complete callback runs only after the driver has completed every delivered
+ * request, so no manual sweep of in-flight requests is needed here.
+ */
 _Function_class_(EVT_UDECX_USB_ENDPOINT_PURGE)
 _IRQL_requires_same_
 void endpoint_purge(_In_ UDECXUSBENDPOINT endpoint)
@@ -264,6 +272,7 @@ PAGED auto create_endpoint_queue(
         WDF_IO_QUEUE_CONFIG_INIT(&cfg, dispatch_type);
         cfg.PowerManaged = WdfFalse;
         cfg.EvtIoInternalDeviceControl = device::internal_control;
+        cfg.EvtIoCanceledOnQueue = device::cancel_queued_request;
 
         WDF_OBJECT_ATTRIBUTES attr;
         WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attr, UDECXUSBENDPOINT);

--- a/drivers/ude/device.cpp
+++ b/drivers/ude/device.cpp
@@ -71,6 +71,8 @@ PAGED void device_cleanup(_In_ WDFOBJECT Object)
         // all resources must be freed
         NT_ASSERT(libdrv::empty(&dev.pending_sends));
         NT_ASSERT(IsListEmpty(&dev.requests));
+        NT_ASSERT(IsListEmpty(&dev.request_completions));
+        NT_ASSERT(!dev.request_completion_dpc_active);
         NT_ASSERT(get_flag(dev.unplugged));
         NT_ASSERT(!dev.port);
         NT_ASSERT(!dev.recv_thread);
@@ -513,9 +515,11 @@ PAGED auto init_device(_In_ UDECXUSBDEVICE device, _Inout_ device_ctx &dev)
         }
 
         InitializeListHead(&dev.requests);
+        InitializeListHead(&dev.request_completions);
         InitializeSListHead(&dev.pending_sends);
+        dev.request_completion_dpc_active = false;
 
-        return STATUS_SUCCESS;
+        return device::create_request_completion_dpc(device, dev);
 }
 
 _IRQL_requires_same_

--- a/drivers/ude/device_ioctl.cpp
+++ b/drivers/ude/device_ioctl.cpp
@@ -49,25 +49,23 @@ NTSTATUS send_complete(_In_ DEVICE_OBJECT*, _In_ IRP *wsk_irp, _In_reads_opt_(_I
 {
         wsk_context_ptr ctx(static_cast<wsk_context*>(context), true);
 
-        auto request = ctx->request; // can be WDF_NO_HANDLE or already completed
+        auto request = ctx->request; // can be WDF_NO_HANDLE
         auto &dev = *ctx->dev;
 
         auto &wsk = wsk_irp->IoStatus;
-        TraceWSK("req %04x -> wsk irp %04x, %!STATUS!, Information %Iu", 
+        TraceWSK("req %04x -> wsk irp %04x, %!STATUS!, Information %Iu",
                   ptr04x(request), ptr04x(wsk_irp), wsk.Status, wsk.Information);
 
         if (!request) {
                 // nothing to do
         } else if (NT_SUCCESS(wsk.Status)) {
                 ++dev.sent_requests;
-                if (auto seqnum = ctx.seqnum(true); auto err = device::mark_request_cancelable(dev, seqnum)) {
+                if (auto err = device::on_send_complete(dev, request, wsk.Status)) {
                         auto device = get_handle(&dev);
                         device::send_cmd_unlink_and_complete(device, request, err);
                 }
-        } else if (device::remove_request(dev, request, false)) {
-                complete(request, wsk.Status);
         } else {
-                TraceDbg("req %04x not found, could not complete", ptr04x(request));
+                NT_VERIFY(NT_SUCCESS(device::on_send_complete(dev, request, wsk.Status)));
         }
 
         if (wsk.Status == STATUS_FILE_FORCED_CLOSED && !get_flag(dev.unplugged)) {
@@ -160,6 +158,12 @@ auto send(_In_opt_ UDECXUSBENDPOINT endpoint, _Inout_ wsk_context_ptr &ctx, _Ino
 {
         auto request = ctx->request; // can be WDF_NO_HANDLE, do not access after send
 
+        if (request && endpoint) {
+                if (auto status = device::initialize_request(dev, request, endpoint)) {
+                        return status;
+                }
+        }
+
         if (auto &buf = ctx->wsk_buf; auto err = prepare_wsk_buf(buf, *ctx, transfer_buffer)) {
                 return err;
         } else {
@@ -169,7 +173,7 @@ auto send(_In_opt_ UDECXUSBENDPOINT endpoint, _Inout_ wsk_context_ptr &ctx, _Ino
         }
 
         if (request && endpoint) {
-                device::append_request(dev, *ctx, endpoint);
+                device::append_request(dev, *ctx);
         }
 
         byteswap_header(ctx->hdr, swap_dir::host2net);
@@ -665,11 +669,11 @@ void NTAPI usbip::device::internal_control(
         auto endpoint = get_endpoint(queue);
         auto &endp = *get_endpoint_ctx(endpoint);
         auto &dev = *get_device_ctx(endp.device);
-        if (auto status = ensure_request_context(request, endpoint)) {
+        if (auto status = initialize_request(dev, request, endpoint)) {
                 UdecxUrbCompleteWithNtStatus(request, status); // low-resource fallback, cannot use the DPC without request_ctx
                 return;
         }
-
+        
         if (get_flag(dev.unplugged)) {
                 get_urb(request).UrbHeader.Status = USBD_STATUS_DEVICE_GONE;
                 complete(request, STATUS_SUCCESS);

--- a/drivers/ude/device_ioctl.cpp
+++ b/drivers/ude/device_ioctl.cpp
@@ -51,27 +51,40 @@ NTSTATUS send_complete(_In_ DEVICE_OBJECT*, _In_ IRP *wsk_irp, _In_reads_opt_(_I
 
         auto request = ctx->request; // can be WDF_NO_HANDLE
         auto &dev = *ctx->dev;
+        auto seqnum = request ? ctx.seqnum(true) : seqnum_t{};
 
         auto &wsk = wsk_irp->IoStatus;
-        TraceWSK("req %04x -> wsk irp %04x, %!STATUS!, Information %Iu",
-                  ptr04x(request), ptr04x(wsk_irp), wsk.Status, wsk.Information);
+        auto wsk_status = wsk.Status;
+        TraceWSK("req %04x -> wsk irp %04x, %!STATUS!, Information %Iu", 
+                  ptr04x(request), ptr04x(wsk_irp), wsk_status, wsk.Information);
 
+        /*
+         * WskSend is finished. Drop the partial MDL before publishing send completion:
+         * it describes pages owned by the upper URB and does not lock them itself.
+         */
+        ctx->mdl_hdr.next(nullptr);
+        ctx->mdl_buf.reset();
+
+        if (wsk_status == STATUS_FILE_FORCED_CLOSED && !get_flag(dev.unplugged)) {
+                auto device = get_handle(&dev);
+                TraceDbg("dev %04x, unplugging after %!STATUS!", ptr04x(device), wsk_status);
+                device::async_detach_and_delete(device, true);
+        }
+
+        /*
+         * Publishing send completion is the last operation: the completion DPC can
+         * complete the request on another processor immediately after that.
+         */
         if (!request) {
                 // nothing to do
-        } else if (NT_SUCCESS(wsk.Status)) {
+        } else if (NT_SUCCESS(wsk_status)) {
                 ++dev.sent_requests;
-                if (auto err = device::on_send_complete(dev, request, wsk.Status)) {
+                if (auto err = device::on_send_complete(dev, request, seqnum, wsk_status)) {
                         auto device = get_handle(&dev);
                         device::send_cmd_unlink_and_complete(device, request, err);
                 }
         } else {
-                NT_VERIFY(NT_SUCCESS(device::on_send_complete(dev, request, wsk.Status)));
-        }
-
-        if (wsk.Status == STATUS_FILE_FORCED_CLOSED && !get_flag(dev.unplugged)) {
-                auto device = get_handle(&dev);
-                TraceDbg("dev %04x, unplugging after %!STATUS!", ptr04x(device), wsk.Status);
-                device::async_detach_and_delete(device, true);
+                NT_VERIFY(NT_SUCCESS(device::on_send_complete(dev, request, seqnum, wsk_status)));
         }
 
         return StopCompletion;

--- a/drivers/ude/device_ioctl.cpp
+++ b/drivers/ude/device_ioctl.cpp
@@ -429,36 +429,11 @@ auto isoch_transfer(
         return send(endpoint, ctx, dev, false, &urb);
 }
 
-/*
- * @see WdfRequestForwardToParentDeviceIoQueue
- */
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-auto allocate_request_ctx(_In_ WDFREQUEST request)
-{
-        WDF_OBJECT_ATTRIBUTES attr;
-        WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attr, request_ctx); // as for WdfDeviceInitSetRequestAttributes
-
-        if (auto err = WdfObjectAllocateContext(request, &attr, nullptr)) {
-                Trace(TRACE_LEVEL_ERROR, "WdfObjectAllocateContext %!STATUS!", err);
-                return err;
-        }
-
-        TraceDbg("%04x", ptr04x(request));
-        return STATUS_SUCCESS;
-}
-
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 auto usb_submit_urb(
         _In_ device_ctx &dev, _In_ UDECXUSBENDPOINT endpoint, _In_ endpoint_ctx &endp, _In_ WDFREQUEST request)
 {
-        if (get_request_ctx(request)) [[likely]] {
-                // NULL for some devices
-        } else if (auto err = allocate_request_ctx(request)) {
-                return err;
-        }
-
         auto &urb = get_urb(request);
         urb_function_t *handler{};
 
@@ -689,13 +664,19 @@ void NTAPI usbip::device::internal_control(
 
         auto endpoint = get_endpoint(queue);
         auto &endp = *get_endpoint_ctx(endpoint);
-        
-        if (auto dev = get_device_ctx(endp.device); get_flag(dev->unplugged)) {
-                UdecxUrbComplete(request, USBD_STATUS_DEVICE_GONE);
-        } else if (auto st = usb_submit_urb(*dev, endpoint, endp, request); st != STATUS_PENDING) {
+        auto &dev = *get_device_ctx(endp.device);
+        if (auto status = ensure_request_context(request, endpoint)) {
+                UdecxUrbCompleteWithNtStatus(request, status); // low-resource fallback, cannot use the DPC without request_ctx
+                return;
+        }
+
+        if (get_flag(dev.unplugged)) {
+                get_urb(request).UrbHeader.Status = USBD_STATUS_DEVICE_GONE;
+                complete(request, STATUS_SUCCESS);
+        } else if (auto st = usb_submit_urb(dev, endpoint, endp, request); st != STATUS_PENDING) {
                 if (st) {
                         TraceDbg("%!STATUS!", st);
                 }
-                UdecxUrbCompleteWithNtStatus(request, st);
+                complete(request, st);
         }
 }

--- a/drivers/ude/request_list.cpp
+++ b/drivers/ude/request_list.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 Vadym Hrynchyshyn <vadimgrn@gmail.com>
+ * Copyright (c) 2022-2026 Vadym Hrynchyshyn <vadimgrn@gmail.com>
  */
 
 #include "request_list.h"
@@ -16,6 +16,28 @@ namespace
 
 using namespace usbip;
 
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void check_request_locked(_In_ [[maybe_unused]] const request_ctx &req)
+{
+        NT_ASSERT(req.endpoint);
+        NT_ASSERT(!req.cancelable || req.listed);
+        NT_ASSERT(!req.response_in_progress || (!req.listed && !req.cancelable));
+        NT_ASSERT(!req.terminal || (!req.listed && !req.cancelable && !req.response_in_progress));
+        NT_ASSERT(!req.completion_queued || (req.terminal && !req.response_in_progress));
+}
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void remove_listed_locked(_Inout_ request_ctx &req)
+{
+        if (req.listed) {
+                RemoveEntryList(&req.entry);
+                InitializeListHead(&req.entry);
+                req.listed = false;
+        }
+}
+
 /*
  * @return true if the caller must enqueue device_ctx::request_completion_dpc.
  * requests_lock must be held.
@@ -24,7 +46,10 @@ _IRQL_requires_same_
 _IRQL_requires_(DISPATCH_LEVEL)
 bool arm_completion_locked(_Inout_ device_ctx &dev, _Inout_ request_ctx &req)
 {
-        if (req.completion_queued) {
+        if (!req.terminal || req.listed || req.cancelable ||
+             req.response_in_progress || req.completion_queued) {
+                // a terminal request must be unlisted and not cancelable; refuse to complete otherwise
+                NT_ASSERT(!req.terminal || (!req.listed && !req.cancelable));
                 return false;
         }
 
@@ -72,6 +97,7 @@ void request_completion_dpc(_In_ WDFDPC dpc)
                         auto req = CONTAINING_RECORD(entry, request_ctx, completion_entry);
 
                         InitializeListHead(&req->completion_entry);
+                        check_request_locked(*req);
 
                         request = get_handle(req);
                         status = req->completion_status;
@@ -82,33 +108,22 @@ void request_completion_dpc(_In_ WDFDPC dpc)
         }
 }
 
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-auto matches(_In_ WDFREQUEST request, _In_ const request_ctx &req, _In_ const device::request_search &crit)
-{
-        switch (crit.what) {
-        case crit.SEQNUM:
-                return crit.seqnum == req.seqnum;
-        case crit.REQUEST:
-                return crit.request == request;
-        case crit.ENDPOINT:
-                return crit.endpoint == req.endpoint;
-        }
-
-        Trace(TRACE_LEVEL_ERROR, "Invalid union member selector %d", crit.what);
-        return false;
-}
-
 _Function_class_(EVT_WDF_REQUEST_CANCEL)
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void cancel_request(_In_ WDFREQUEST request)
 {
-        auto device = get_device(request);
-        auto dev = get_device_ctx(device);
+        auto &req = *get_request_ctx(request);
+        auto endpoint = req.endpoint;
+        auto device = get_endpoint_ctx(endpoint)->device;
+        auto &dev = *get_device_ctx(device);
 
-        bool removed = device::remove_request(*dev, request, false); // can clash with concurrent remove_request(, true)
-        TraceDbg("%04x, removed %d", ptr04x(request), removed);
+        {
+                wdf::Lock lck(dev.requests_lock);
+                remove_listed_locked(req);
+                req.cancelable = false;
+                check_request_locked(req);
+        }
 
         device::send_cmd_unlink_and_cancel(device, request);
 }
@@ -136,7 +151,8 @@ PAGED NTSTATUS usbip::device::create_request_completion_dpc(
 
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
-NTSTATUS usbip::device::ensure_request_context(_In_ WDFREQUEST request, _In_ UDECXUSBENDPOINT endpoint)
+NTSTATUS usbip::device::initialize_request(
+        _Inout_ device_ctx &dev, _In_ WDFREQUEST request, _In_ UDECXUSBENDPOINT endpoint)
 {
         NT_ASSERT(endpoint);
         auto req = get_request_ctx(request);
@@ -152,14 +168,159 @@ NTSTATUS usbip::device::ensure_request_context(_In_ WDFREQUEST request, _In_ UDE
                 }
         }
 
+        wdf::Lock lck(dev.requests_lock);
+
         // A WDFREQUEST can be reused; its context is not zeroed between transfers.
+        NT_ASSERT(!req->listed);
+        NT_ASSERT(!req->response_in_progress);
+
+        InitializeListHead(&req->entry);
         InitializeListHead(&req->completion_entry);
         req->endpoint = endpoint;
         req->seqnum = {};
         req->completion_status = STATUS_PENDING;
+        req->listed = false;
+        req->cancelable = false;
+        req->response_in_progress = false;
+        req->terminal = false;
         req->completion_queued = false;
 
+        check_request_locked(*req);
         return STATUS_SUCCESS;
+}
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void usbip::device::append_request(_Inout_ device_ctx &dev, _In_ const wsk_context &wsk)
+{
+        auto &req = *get_request_ctx(wsk.request);
+
+        wdf::Lock lck(dev.requests_lock);
+
+        NT_ASSERT(req.endpoint);
+        NT_ASSERT(!req.listed);
+        NT_ASSERT(!req.terminal);
+
+        req.seqnum = wsk.hdr.seqnum;
+        NT_ASSERT(is_valid_seqnum(req.seqnum));
+
+        req.listed = true;
+        InsertTailList(&dev.requests, &req.entry);
+        check_request_locked(req);
+}
+
+/*
+ * @return a WdfRequestMarkCancelableEx error. The caller must issue UNLINK and
+ *         finish the request for that error.
+ */
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS usbip::device::on_send_complete(
+        _Inout_ device_ctx &dev,
+        _In_ WDFREQUEST request,
+        _In_ NTSTATUS send_status)
+{
+        bool enqueue{};
+        NTSTATUS mark_status = STATUS_SUCCESS;
+
+        {
+                wdf::Lock lck(dev.requests_lock);
+                auto &req = *get_request_ctx(request);
+
+                if (!NT_SUCCESS(send_status)) {
+                        remove_listed_locked(req);
+                        // a response or cancellation that already owns the request has status precedence
+                        if (!(req.terminal || req.response_in_progress)) {
+                                req.completion_status = send_status;
+                                req.terminal = true;
+                        }
+                } else if (req.terminal || req.response_in_progress) {
+                        // RET_SUBMIT or cancellation won the race with WskSend completion.
+                } else if (!req.listed) {
+                        NT_ASSERT(false);
+                        mark_status = STATUS_INVALID_DEVICE_STATE;
+                } else if (auto err = WdfRequestMarkCancelableEx(request, cancel_request)) {
+                        mark_status = err; // STATUS_CANCELLED if the queue is being purged
+                        remove_listed_locked(req);
+                } else {
+                        req.cancelable = true;
+                        ++dev.cancelable_requests;
+                }
+
+                enqueue = arm_completion_locked(dev, req);
+                check_request_locked(req);
+        }
+
+        enqueue_completion_dpc_if_needed(dev, enqueue);
+        return mark_status;
+}
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+WDFREQUEST usbip::device::begin_response(_Inout_ device_ctx &dev, _In_ seqnum_t seqnum)
+{
+        NT_ASSERT(is_valid_seqnum(seqnum));
+        WDFREQUEST request = WDF_NO_HANDLE;
+
+        wdf::Lock lck(dev.requests_lock);
+
+        for (auto head = &dev.requests, entry = head->Flink; entry != head; entry = entry->Flink) {
+                auto req = CONTAINING_RECORD(entry, request_ctx, entry);
+                if (req->seqnum != seqnum) {
+                        continue;
+                }
+
+                request = get_handle(req);
+                remove_listed_locked(*req);
+
+                if (req->cancelable) {
+                        auto status = WdfRequestUnmarkCancelable(request);
+                        req->cancelable = false;
+
+                        if (status == STATUS_CANCELLED) {
+                                request = WDF_NO_HANDLE;
+                        } else {
+                                NT_ASSERT(NT_SUCCESS(status));
+                        }
+                }
+
+                if (request) {
+                        req->response_in_progress = true;
+                        check_request_locked(*req);
+                }
+                break;
+        }
+
+        return request;
+}
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void usbip::device::finish_response(_In_ WDFREQUEST request, _In_ NTSTATUS status)
+{
+        auto &req = *get_request_ctx(request);
+        auto device = get_endpoint_ctx(req.endpoint)->device;
+        auto &dev = *get_device_ctx(device);
+        bool enqueue{};
+
+        {
+                wdf::Lock lck(dev.requests_lock);
+                NT_ASSERT(req.response_in_progress);
+                req.response_in_progress = false;
+
+                // Preserve an earlier terminal owner; otherwise the claimed response
+                // supplies the completion status.
+                NT_ASSERT(!req.terminal);
+                if (!req.terminal) {
+                        req.completion_status = status;
+                        req.terminal = true;
+                }
+
+                enqueue = arm_completion_locked(dev, req);
+                check_request_locked(req);
+        }
+
+        enqueue_completion_dpc_if_needed(dev, enqueue);
 }
 
 _IRQL_requires_same_
@@ -174,101 +335,15 @@ void usbip::device::finish_request(_In_ WDFREQUEST request, _In_ NTSTATUS status
         {
                 wdf::Lock lck(dev.requests_lock);
 
-                if (!req.completion_queued) {
+                if (!req.terminal) {
                         req.completion_status = status;
+                        req.terminal = true;
                 }
 
                 enqueue = arm_completion_locked(dev, req);
+                check_request_locked(req);
         }
 
         enqueue_completion_dpc_if_needed(dev, enqueue);
 }
 
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-void usbip::device::append_request(_Inout_ device_ctx &dev, _In_ const wsk_context &wsk, _In_ UDECXUSBENDPOINT endpoint)
-{
-        auto &req = *get_request_ctx(wsk.request); // is not zeroed
-        req.cancelable = false;
-
-        NT_ASSERT(endpoint);
-        req.endpoint = endpoint;
-
-        req.seqnum = wsk.hdr.seqnum;
-        NT_ASSERT(is_valid_seqnum(req.seqnum));
-
-        wdf::Lock lck(dev.requests_lock);
-        InsertTailList(&dev.requests, &req.entry);
-}
-
-/*
- * seqnum is used instead of WDFREQUEST because
- * - request can be already completed and must be used for value comparison only
- * - if request is completed, the same request instance can be allocated from a cache
- *   for next transfer and put in the list
- */
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-NTSTATUS usbip::device::mark_request_cancelable(_Inout_ device_ctx &dev, _In_ seqnum_t seqnum)
-{
-        NT_ASSERT(is_valid_seqnum(seqnum));
-
-        wdf::Lock lck(dev.requests_lock);
-
-        for (auto head = &dev.requests, entry = head->Flink; entry != head; entry = entry->Flink) {
-
-                if (auto req = CONTAINING_RECORD(entry, request_ctx, entry); req->seqnum != seqnum) {
-                        // continue;
-                } else if (auto request = get_handle(req); auto err = WdfRequestMarkCancelableEx(request, cancel_request)) {
-                        TraceDbg("%04x, %!STATUS!", ptr04x(request), err);
-                        RemoveEntryList(entry);
-                        return err; // must do the same as cancel_request after that
-                } else {
-                        req->cancelable = true;
-                        ++dev.cancelable_requests;
-                        break;
-                }
-        }
-
-        return STATUS_SUCCESS;
-}
-
-/*
- * Its rival is cancel_request if it is marked cancellable, otherwise mark_request_cancelable.
- */
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-WDFREQUEST usbip::device::remove_request(
-        _Inout_ device_ctx &dev, _In_ const request_search &crit, _In_ bool unmark_cancelable)
-{
-        wdf::Lock lck(dev.requests_lock);
-
-        for (auto head = &dev.requests, entry = head->Flink; entry != head; entry = entry->Flink) {
-
-                auto req = CONTAINING_RECORD(entry, request_ctx, entry);
-                auto request = get_handle(req);
-
-                if (!matches(request, *req, crit)) {
-                        continue;
-                }
-
-                RemoveEntryList(entry);
-
-                if (!(unmark_cancelable && req->cancelable)) {
-                        // not required
-                } else if (auto ret = WdfRequestUnmarkCancelable(request)) {
-                        TraceDbg("%04x, unmark cancelable %!STATUS!", ptr04x(request), ret);
-                        if (ret != STATUS_CANCELLED) {
-                                // EvtRequestCancel will not be called
-                        } else if (crit.multimatch()) {
-                                continue;
-                        } else {
-                                request = WDF_NO_HANDLE;
-                        }
-                }
-
-                return request;
-        }
-
-        return WDF_NO_HANDLE;
-}

--- a/drivers/ude/request_list.cpp
+++ b/drivers/ude/request_list.cpp
@@ -21,10 +21,11 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 void check_request_locked(_In_ [[maybe_unused]] const request_ctx &req)
 {
         NT_ASSERT(req.endpoint);
-        NT_ASSERT(!req.cancelable || req.listed);
+        NT_ASSERT(!req.cancelable || (req.listed && !req.send_pending));
         NT_ASSERT(!req.response_in_progress || (!req.listed && !req.cancelable));
         NT_ASSERT(!req.terminal || (!req.listed && !req.cancelable && !req.response_in_progress));
-        NT_ASSERT(!req.completion_queued || (req.terminal && !req.response_in_progress));
+        NT_ASSERT(!req.completion_queued ||
+                  (req.terminal && !req.send_pending && !req.response_in_progress));
 }
 
 _IRQL_requires_same_
@@ -47,7 +48,7 @@ _IRQL_requires_(DISPATCH_LEVEL)
 bool arm_completion_locked(_Inout_ device_ctx &dev, _Inout_ request_ctx &req)
 {
         if (!req.terminal || req.listed || req.cancelable ||
-             req.response_in_progress || req.completion_queued) {
+             req.send_pending || req.response_in_progress || req.completion_queued) {
                 // a terminal request must be unlisted and not cancelable; refuse to complete otherwise
                 NT_ASSERT(!req.terminal || (!req.listed && !req.cancelable));
                 return false;
@@ -172,6 +173,7 @@ NTSTATUS usbip::device::initialize_request(
 
         // A WDFREQUEST can be reused; its context is not zeroed between transfers.
         NT_ASSERT(!req->listed);
+        NT_ASSERT(!req->send_pending);
         NT_ASSERT(!req->response_in_progress);
 
         InitializeListHead(&req->entry);
@@ -181,6 +183,7 @@ NTSTATUS usbip::device::initialize_request(
         req->completion_status = STATUS_PENDING;
         req->listed = false;
         req->cancelable = false;
+        req->send_pending = false;
         req->response_in_progress = false;
         req->terminal = false;
         req->completion_queued = false;
@@ -199,17 +202,22 @@ void usbip::device::append_request(_Inout_ device_ctx &dev, _In_ const wsk_conte
 
         NT_ASSERT(req.endpoint);
         NT_ASSERT(!req.listed);
+        NT_ASSERT(!req.send_pending);
         NT_ASSERT(!req.terminal);
 
         req.seqnum = wsk.hdr.seqnum;
         NT_ASSERT(is_valid_seqnum(req.seqnum));
 
         req.listed = true;
+        req.send_pending = true;
         InsertTailList(&dev.requests, &req.entry);
         check_request_locked(req);
 }
 
 /*
+ * The WDFREQUEST cannot be completed until this function clears send_pending.
+ * That keeps the upper URB TransferBufferMDL valid for the entire WskSend.
+ *
  * @return a WdfRequestMarkCancelableEx error. The caller must issue UNLINK and
  *         finish the request for that error.
  */
@@ -218,6 +226,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 NTSTATUS usbip::device::on_send_complete(
         _Inout_ device_ctx &dev,
         _In_ WDFREQUEST request,
+        _In_ seqnum_t seqnum,
         _In_ NTSTATUS send_status)
 {
         bool enqueue{};
@@ -226,6 +235,15 @@ NTSTATUS usbip::device::on_send_complete(
         {
                 wdf::Lock lck(dev.requests_lock);
                 auto &req = *get_request_ctx(request);
+
+                NT_ASSERT(req.seqnum == seqnum);
+                NT_ASSERT(req.send_pending);
+
+                if (req.seqnum != seqnum || !req.send_pending) {
+                        return STATUS_INVALID_DEVICE_STATE;
+                }
+
+                req.send_pending = false;
 
                 if (!NT_SUCCESS(send_status)) {
                         remove_listed_locked(req);

--- a/drivers/ude/request_list.cpp
+++ b/drivers/ude/request_list.cpp
@@ -9,11 +9,78 @@
 #include "context.h"
 #include "wsk_context.h"
 #include "device_ioctl.h"
+#include "wsk_receive.h"
 
 namespace
 {
 
 using namespace usbip;
+
+/*
+ * @return true if the caller must enqueue device_ctx::request_completion_dpc.
+ * requests_lock must be held.
+ */
+_IRQL_requires_same_
+_IRQL_requires_(DISPATCH_LEVEL)
+bool arm_completion_locked(_Inout_ device_ctx &dev, _Inout_ request_ctx &req)
+{
+        if (req.completion_queued) {
+                return false;
+        }
+
+        req.completion_queued = true;
+        InsertTailList(&dev.request_completions, &req.completion_entry);
+
+        if (dev.request_completion_dpc_active) {
+                return false;
+        }
+
+        dev.request_completion_dpc_active = true;
+        return true;
+}
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void enqueue_completion_dpc_if_needed(_Inout_ device_ctx &dev, _In_ bool enqueue)
+{
+        if (enqueue) {
+                NT_VERIFY(WdfDpcEnqueue(dev.request_completion_dpc));
+        }
+}
+
+_Function_class_(EVT_WDF_DPC)
+_IRQL_requires_same_
+_IRQL_requires_(DISPATCH_LEVEL)
+void request_completion_dpc(_In_ WDFDPC dpc)
+{
+        auto device = static_cast<UDECXUSBDEVICE>(WdfDpcGetParentObject(dpc));
+        auto &dev = *get_device_ctx(device);
+
+        for (;;) {
+                WDFREQUEST request;
+                NTSTATUS status;
+
+                {
+                        wdf::Lock lck(dev.requests_lock);
+
+                        if (IsListEmpty(&dev.request_completions)) {
+                                dev.request_completion_dpc_active = false;
+                                return;
+                        }
+
+                        auto entry = RemoveHeadList(&dev.request_completions);
+                        auto req = CONTAINING_RECORD(entry, request_ctx, completion_entry);
+
+                        InitializeListHead(&req->completion_entry);
+
+                        request = get_handle(req);
+                        status = req->completion_status;
+                }
+
+                // Do not touch request or its context after this call. UDE can reuse it immediately.
+                complete_now(request, status);
+        }
+}
 
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -48,6 +115,74 @@ void cancel_request(_In_ WDFREQUEST request)
 
 } // namespace
 
+
+_IRQL_requires_same_
+_IRQL_requires_(PASSIVE_LEVEL)
+PAGED NTSTATUS usbip::device::create_request_completion_dpc(
+        _In_ UDECXUSBDEVICE device, _Inout_ device_ctx &dev)
+{
+        PAGED_CODE();
+
+        WDF_DPC_CONFIG cfg;
+        WDF_DPC_CONFIG_INIT(&cfg, request_completion_dpc);
+        cfg.AutomaticSerialization = FALSE;
+
+        WDF_OBJECT_ATTRIBUTES attr;
+        WDF_OBJECT_ATTRIBUTES_INIT(&attr);
+        attr.ParentObject = device;
+
+        return WdfDpcCreate(&cfg, &attr, &dev.request_completion_dpc);
+}
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS usbip::device::ensure_request_context(_In_ WDFREQUEST request, _In_ UDECXUSBENDPOINT endpoint)
+{
+        NT_ASSERT(endpoint);
+        auto req = get_request_ctx(request);
+
+        if (!req) {
+                WDF_OBJECT_ATTRIBUTES attr;
+                WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attr, request_ctx);
+
+                if (auto status = WdfObjectAllocateContext(
+                        request, &attr, reinterpret_cast<void**>(&req))) {
+                        Trace(TRACE_LEVEL_ERROR, "WdfObjectAllocateContext %!STATUS!", status);
+                        return status;
+                }
+        }
+
+        // A WDFREQUEST can be reused; its context is not zeroed between transfers.
+        InitializeListHead(&req->completion_entry);
+        req->endpoint = endpoint;
+        req->seqnum = {};
+        req->completion_status = STATUS_PENDING;
+        req->completion_queued = false;
+
+        return STATUS_SUCCESS;
+}
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void usbip::device::finish_request(_In_ WDFREQUEST request, _In_ NTSTATUS status)
+{
+        auto &req = *get_request_ctx(request);
+        auto device = get_endpoint_ctx(req.endpoint)->device;
+        auto &dev = *get_device_ctx(device);
+        bool enqueue{};
+
+        {
+                wdf::Lock lck(dev.requests_lock);
+
+                if (!req.completion_queued) {
+                        req.completion_status = status;
+                }
+
+                enqueue = arm_completion_locked(dev, req);
+        }
+
+        enqueue_completion_dpc_if_needed(dev, enqueue);
+}
 
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/drivers/ude/request_list.cpp
+++ b/drivers/ude/request_list.cpp
@@ -347,3 +347,17 @@ void usbip::device::finish_request(_In_ WDFREQUEST request, _In_ NTSTATUS status
         enqueue_completion_dpc_if_needed(dev, enqueue);
 }
 
+_Function_class_(EVT_WDF_IO_QUEUE_IO_CANCELED_ON_QUEUE)
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void usbip::device::cancel_queued_request(_In_ WDFQUEUE queue, _In_ WDFREQUEST request)
+{
+        auto endpoint = get_endpoint(queue);
+        auto &dev = *get_device_ctx(get_endpoint_ctx(endpoint)->device);
+
+        if (auto status = initialize_request(dev, request, endpoint)) {
+                UdecxUrbCompleteWithNtStatus(request, status); // low-resource fallback, cannot use the DPC without request_ctx
+                return;
+        }
+        finish_request(request, STATUS_CANCELLED);
+}

--- a/drivers/ude/request_list.h
+++ b/drivers/ude/request_list.h
@@ -46,6 +46,18 @@ struct request_search
 
 
 _IRQL_requires_same_
+_IRQL_requires_(PASSIVE_LEVEL)
+PAGED NTSTATUS create_request_completion_dpc(_In_ UDECXUSBDEVICE device, _Inout_ device_ctx &dev);
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS ensure_request_context(_In_ WDFREQUEST request, _In_ UDECXUSBENDPOINT endpoint);
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void finish_request(_In_ WDFREQUEST request, _In_ NTSTATUS status);
+
+_IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void append_request(_Inout_ device_ctx &dev, _In_ const wsk_context &wsk, _In_ UDECXUSBENDPOINT endpoint);
 

--- a/drivers/ude/request_list.h
+++ b/drivers/ude/request_list.h
@@ -34,7 +34,8 @@ void append_request(_Inout_ device_ctx &dev, _In_ const wsk_context &wsk);
 
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
-NTSTATUS on_send_complete(_Inout_ device_ctx &dev, _In_ WDFREQUEST request, _In_ NTSTATUS send_status);
+NTSTATUS on_send_complete(
+        _Inout_ device_ctx &dev, _In_ WDFREQUEST request, _In_ seqnum_t seqnum, _In_ NTSTATUS send_status);
 
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)

--- a/drivers/ude/request_list.h
+++ b/drivers/ude/request_list.h
@@ -48,4 +48,9 @@ _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void finish_request(_In_ WDFREQUEST request, _In_ NTSTATUS status);
 
+_Function_class_(EVT_WDF_IO_QUEUE_IO_CANCELED_ON_QUEUE)
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void cancel_queued_request(_In_ WDFQUEUE queue, _In_ WDFREQUEST request);
+
 } // namespace usbip::device

--- a/drivers/ude/request_list.h
+++ b/drivers/ude/request_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 Vadym Hrynchyshyn <vadimgrn@gmail.com>
+ * Copyright (c) 2022-2026 Vadym Hrynchyshyn <vadimgrn@gmail.com>
  */
 
 #pragma once
@@ -20,53 +20,32 @@ namespace usbip
 namespace usbip::device
 {
 
-struct request_search
-{
-        request_search(_In_ WDFREQUEST req) : request(req), what(REQUEST) {}
-        request_search(_In_ UDECXUSBENDPOINT endp) : endpoint(endp), what(ENDPOINT) {}
-
-        request_search(_In_ seqnum_t n) : 
-                request(reinterpret_cast<WDFREQUEST>(static_cast<uintptr_t>(n))), // for operator bool correctness
-                what(SEQNUM) { NT_ASSERT(seqnum == n); }
-
-        explicit operator bool() const { return request; }; // largest in union
-        auto operator !() const { return !request; }
-
-        auto multimatch() const { return what == ENDPOINT; }
-
-        union {
-                WDFREQUEST request{};
-                UDECXUSBENDPOINT endpoint;
-                seqnum_t seqnum;
-        };
-
-        enum what_t { SEQNUM, REQUEST, ENDPOINT };
-        what_t what; // union's member selector
-};
-
-
 _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)
 PAGED NTSTATUS create_request_completion_dpc(_In_ UDECXUSBDEVICE device, _Inout_ device_ctx &dev);
 
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
-NTSTATUS ensure_request_context(_In_ WDFREQUEST request, _In_ UDECXUSBENDPOINT endpoint);
+NTSTATUS initialize_request(_Inout_ device_ctx &dev, _In_ WDFREQUEST request, _In_ UDECXUSBENDPOINT endpoint);
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void append_request(_Inout_ device_ctx &dev, _In_ const wsk_context &wsk);
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS on_send_complete(_Inout_ device_ctx &dev, _In_ WDFREQUEST request, _In_ NTSTATUS send_status);
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+WDFREQUEST begin_response(_Inout_ device_ctx &dev, _In_ seqnum_t seqnum);
+
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+void finish_response(_In_ WDFREQUEST request, _In_ NTSTATUS status);
 
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void finish_request(_In_ WDFREQUEST request, _In_ NTSTATUS status);
-
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-void append_request(_Inout_ device_ctx &dev, _In_ const wsk_context &wsk, _In_ UDECXUSBENDPOINT endpoint);
-
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-NTSTATUS mark_request_cancelable(_Inout_ device_ctx &dev, _In_ seqnum_t seqnum);
-
-_IRQL_requires_same_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-WDFREQUEST remove_request(_Inout_ device_ctx &dev, _In_ const request_search &crit, _In_ bool unmark_cancelable = true);
 
 } // namespace usbip::device

--- a/drivers/ude/wsk_receive.cpp
+++ b/drivers/ude/wsk_receive.cpp
@@ -460,7 +460,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL)
 WDFREQUEST usbip::ret_command(_In_ const header &hdr, _Inout_ device_ctx &dev)
 {
 	auto request = hdr.command == RET_SUBMIT ? // request must be completed
-		       device::remove_request(dev, hdr.seqnum) : WDF_NO_HANDLE;
+		       device::begin_response(dev, hdr.seqnum) : WDF_NO_HANDLE;
 
 	char buf[DBG_USBIP_HDR_BUFSZ];
 	TraceEvents(TRACE_LEVEL_VERBOSE, FLAG_USBIP, "req %04x <- %Iu%s", ptr04x(request), 
@@ -519,8 +519,8 @@ bool usbip::validate(_Inout_ header &hdr)
 
 
 /*
- * Publish a terminal request status. The device completion DPC performs the
- * actual UDE completion.
+ * Publish a terminal request state. The device completion DPC performs the
+ * actual UDE completion after both response processing and WskSend are done.
  * @see Write a UDE client driver
  */
 _IRQL_requires_same_
@@ -562,7 +562,7 @@ void usbip::complete_now(_In_ WDFREQUEST request, _In_ NTSTATUS status)
 	}
 
 	if (status || urb_st) {
-		TraceUrb("seqnum %u, USBD_%s, %!STATUS!, Information %#Ix",
+		TraceUrb("seqnum %u, USBD_%s, %!STATUS!, Information %#Ix", 
 			  req.seqnum, get_usbd_status(urb_st), status, info);
 	}
 

--- a/drivers/ude/wsk_receive.cpp
+++ b/drivers/ude/wsk_receive.cpp
@@ -519,13 +519,26 @@ bool usbip::validate(_Inout_ header &hdr)
 
 
 /*
- * To ensure compatibility with existing USB drivers, the UDE client must call WdfRequestComplete at DISPATCH_LEVEL.
+ * Publish a terminal request status. The device completion DPC performs the
+ * actual UDE completion.
  * @see Write a UDE client driver
  */
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void usbip::complete(_In_ WDFREQUEST request, _In_ NTSTATUS status)
 {
+	device::finish_request(request, status);
+}
+
+/*
+ * UDE requires URBs to be completed from a separate DPC at DISPATCH_LEVEL.
+ * This routine is called only by request_completion_dpc.
+ */
+_IRQL_requires_same_
+_IRQL_requires_(DISPATCH_LEVEL)
+void usbip::complete_now(_In_ WDFREQUEST request, _In_ NTSTATUS status)
+{
+	NT_ASSERT(KeGetCurrentIrql() == DISPATCH_LEVEL);
 	auto irp = WdfRequestWdmGetIrp(request);
 
 	auto info = irp->IoStatus.Information;
@@ -537,7 +550,6 @@ void usbip::complete(_In_ WDFREQUEST request, _In_ NTSTATUS status)
 		if (status) {
 			TraceUrb("seqnum %u, %!STATUS!, Information %#Ix", req.seqnum, status, info);
 		}
-		libdrv::RaiseIrql lvl(DISPATCH_LEVEL);
 		WdfRequestComplete(request, status);
 		return;
 	}
@@ -550,11 +562,9 @@ void usbip::complete(_In_ WDFREQUEST request, _In_ NTSTATUS status)
 	}
 
 	if (status || urb_st) {
-		TraceUrb("seqnum %u, USBD_%s, %!STATUS!, Information %#Ix", 
+		TraceUrb("seqnum %u, USBD_%s, %!STATUS!, Information %#Ix",
 			  req.seqnum, get_usbd_status(urb_st), status, info);
 	}
-
-	libdrv::RaiseIrql lvl(DISPATCH_LEVEL);
 
 	if (NT_SUCCESS(status)) {
 		UdecxUrbComplete(request, urb_st);

--- a/drivers/ude/wsk_receive.h
+++ b/drivers/ude/wsk_receive.h
@@ -29,6 +29,10 @@ _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 void complete(_In_ WDFREQUEST request, _In_ NTSTATUS status);
 
+_IRQL_requires_same_
+_IRQL_requires_(DISPATCH_LEVEL)
+void complete_now(_In_ WDFREQUEST request, _In_ NTSTATUS status);
+
 /*
  * ret_submit() set URB.UrbHeader.Status, atomic_complete set IRP.IoStatus.Status
  */

--- a/drivers/ude/wsk_receive_events.cpp
+++ b/drivers/ude/wsk_receive_events.cpp
@@ -12,6 +12,7 @@
 #include "ring_buffer.h"
 #include "wsk_context.h"
 #include "wsk_receive.h"
+#include "request_list.h"
 
 #include <libdrv/pdu.h>
 
@@ -73,7 +74,7 @@ auto received(_In_ UDECXUSBDEVICE device, _Inout_ device_ctx &dev, _In_ const ch
                 rb.skip(sizeof(hdr));
 
                 auto st = ret_submit(ctx); // must consume payload
-                complete(ctx.request, st);
+                device::finish_response(ctx.request, st);
 
                 if (rb.size() != expected) [[unlikely]] {
                         Trace(TRACE_LEVEL_ERROR, "dev %04x, ring buffer size %Iu != %Iu", 

--- a/drivers/ude/wsk_receive_irp.cpp
+++ b/drivers/ude/wsk_receive_irp.cpp
@@ -14,6 +14,7 @@
 #include "wsk_receive.h"
 #include "wsk_context.h"
 #include "urbtransfer.h"
+#include "request_list.h"
 
 #include <libdrv/wait_timeout.h>
 #include <libdrv/usbd_helper.h>
@@ -30,7 +31,7 @@ _IRQL_requires_(PASSIVE_LEVEL)
 PAGED void complete_and_set_null(_Inout_ WDFREQUEST &request, _In_ NTSTATUS status)
 {
         PAGED_CODE();
-        complete(request, status);
+        device::finish_response(request, status);
         request = WDF_NO_HANDLE;
 }
 


### PR DESCRIPTION
Implements the fix invited in #181. Likely also covers #180 — same `0x139_1d`/`RtlRbRemoveNode` corruption signature on the same builds, non-audio trigger, and the defects fixed here live in the request machinery common to all transfer types.

## Problem

Two request-lifetime defects in `usbip2_ude` allow kernel pool corruption (`0x139 INVALID_BALANCED_TREE`, wild `0xA` IRQL-2 faults) under concurrent endpoint purge / cancellation / `RET_SUBMIT` / `WskSend` completion. ISO audio pin cycling (`SET_INTERFACE` alt-1/alt-0) hits the window easily, but nothing about the defects is audio-specific:

1. **URBs are completed inline.** `usbip::complete` raised IRQL on the caller's stack and called `WdfRequestComplete`/`UdecxUrbComplete` directly from receive, cancellation and endpoint-purge paths — UDE requires completion from a separate DPC. The purge sweep, `cancel_request` (its comment admitted the clash) and `send_complete` could complete the same `WDFREQUEST` concurrently with the receive path. A WDF IFR capture shows endpoint queue purge overlapping ISO completions on the failing device ~40 µs before a `0x139` in `usbaudio!USBType1FreeRequest` (details in #181).
2. **`WskSend` can outlive the request backing its buffer.** For OUT transfers the send buffer chains a partial MDL built over the upper URB's `TransferBufferMDL`. A partial MDL does not lock the pages it describes, yet the request could complete — and the URB with its buffer be freed or reused — while the send IRP was still pending (`send_complete`'s own comment: the request "can be … already completed").

## Fix — four commits

1. `ude: complete endpoint requests from a dedicated DPC` — terminal status is published exactly once (`completion_queued` under `requests_lock`); a per-device `WDFDPC` performs every completion at `DISPATCH_LEVEL`.
2. `ude: arbitrate response and cancellation ownership of a request` — explicit `listed / cancelable / response_in_progress / terminal` states arbitrate `RET_SUBMIT` processing, WDF cancellation and send failure; first owner wins, the DPC stays the only completer. Works identically for the receive thread and the `wsk_events` callback.
3. `ude: let KMDF queue purge drive endpoint cancellation` — the manual purge/UNLINK sweep is removed. `WdfIoQueuePurge` dispatches `EvtRequestCancel` for cancelable requests; while purging, a late `WdfRequestMarkCancelableEx` fails with `STATUS_CANCELLED` (`FxIoQueue::m_CancelDispatchedRequests`), which send completion turns into `CMD_UNLINK` + deferred cancel-completion; never-delivered requests go through the new `EvtIoCanceledOnQueue`.
4. `ude: retain OUT transfer MDLs until WskSend completes` — a `send_pending` state gates completion until the send IRP finishes; the partial MDL is detached before that, and publishing send completion is the completion routine's final operation.

Known low-resource exception: if `request_ctx` allocation fails at submit/queue-cancel time, the request is completed inline with an error, as before this series.

## Validation

- Builds clean (0 errors / 0 warnings): `usbip2_ude` x64 Release + Debug, ARM64 Release; `ude_filter` x64 + ARM64 Release — VS2026 BuildTools 18.4, WDK/SDK 10.0.28000 NuGet, each commit compiles standalone.
- The reporting machine runs HVCI + Secure Boot, so the self-built driver has not been loaded there; per your offer in #181, an attestation-signed build of this series can be runtime-tested here promptly against the exact workload from the report (emulated `054C:0CE6` composite, ISO streaming, pin-cycle loop), with WPP tracing and full dump armed.
- The state machine and WDF/UDE/WSK reasoning were adversarially reviewed line-by-line by two independent AI review passes before submission; findings (including a status-precedence defect in an earlier draft of the series) were fixed and re-verified.

## Notes for review

- `wsk_events` mode previously completed URBs from inside the WSK receive event callback; it now only publishes terminal state there. The ring-buffer payload copy still happens synchronously in the callback before that, unchanged.
- No protocol, INF or userspace changes. Fast-path behavior for successful transfers changes only by the completion hop through the per-device DPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
