### PR TITLE
Fix attach work-item self-wait that blocks driver unload

### DIFF
--- a/drivers/ude/vhci_ioctl.cpp
+++ b/drivers/ude/vhci_ioctl.cpp
@@ -384,9 +384,13 @@ PAGED auto create_socket(_Inout_ SOCKET* &sock, _In_ const ADDRINFOEXW &ai, _In_
 
 _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)
+PAGED NTSTATUS create_workitem(_Out_ WDFWORKITEM &wi, _In_ WDFOBJECT parent);
+
+_IRQL_requires_same_
+_IRQL_requires_(PASSIVE_LEVEL)
 PAGED auto connect(
         _In_ WDFREQUEST request,
-        _In_ WDFWORKITEM wi, _Inout_ workitem_ctx &ctx,
+        _Inout_ workitem_ctx &ctx,
         _Inout_ device_ctx_ext &ext, _In_ const ADDRINFOEXW &ai)
 {
         PAGED_CODE();
@@ -404,7 +408,22 @@ PAGED auto connect(
                 return st;
         }
 
-        set_args(ctx.args, request, __func__, &ai);
+        // WSK can complete before this callback returns. A fresh work item
+        // keeps the callbacks' worker-thread state separate during deletion.
+        WDFWORKITEM wi{};
+        st = create_workitem(wi, ctx.vhci);
+        if (NT_ERROR(st)) {
+                Trace(TRACE_LEVEL_ERROR, "WdfWorkItemCreate %!STATUS!", st);
+                return st;
+        }
+
+        auto &next = *get_workitem_ctx(wi);
+        next = ctx;
+        ctx.ctx_ext = WDF_NO_HANDLE;
+        ctx.addrinfo = nullptr;
+        ctx.request = WDF_NO_HANDLE;
+
+        set_args(next.args, request, __func__, &ai);
 
         auto irp = WdfRequestWdmGetIrp(request);
         IoSetCompletionRoutine(irp, irp_complete, wi, true, true, true);
@@ -419,7 +438,6 @@ _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)
 PAGED auto on_connect(
         _In_ WDFREQUEST request,
-        _In_ WDFWORKITEM wi, 
         _Inout_ workitem_ctx &ctx,
         _Inout_ device_ctx_ext &ext,
         _In_ const ADDRINFOEXW &ai)
@@ -436,7 +454,7 @@ PAGED auto on_connect(
                 free(ext.sock);
 
                 if (st != STATUS_CANCELLED && ai.ai_next) {
-                        st = connect(request, wi, ctx, ext, *ai.ai_next);
+                        st = connect(request, ctx, ext, *ai.ai_next);
                 }
         }
 
@@ -466,13 +484,15 @@ PAGED void NTAPI complete(_In_ WDFWORKITEM wi)
                 st = STATUS_CANCELLED;
                 TraceDbg("req %04x, set %!STATUS!, vhci is being removing", ptr04x(request), st);
         } else if (auto ai = ctx.args.ai) {
-                st = on_connect(request, wi, ctx, ext, *ai);
+                st = on_connect(request, ctx, ext, *ai);
         } else if (NT_SUCCESS(st)) { // on_addrinfo
                 NT_ASSERT(ctx.addrinfo);
-                st = connect(request, wi, ctx, ext, *ctx.addrinfo);
+                st = connect(request, ctx, ext, *ctx.addrinfo);
         }
 
         if (st == STATUS_PENDING) {
+                // The successor owns the request and allocation cleanup.
+                WdfObjectDelete(wi);
                 return;
         }
 
@@ -523,7 +543,7 @@ PAGED void workitem_cleanup(_In_ WDFOBJECT object)
 
 _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)
-PAGED auto create_workitem(_Out_ WDFWORKITEM &wi, _In_ WDFOBJECT parent)
+PAGED NTSTATUS create_workitem(_Out_ WDFWORKITEM &wi, _In_ WDFOBJECT parent)
 {
         PAGED_CODE();
 


### PR DESCRIPTION
A successful attach can leave a USB/IP worker waiting on itself in `WdfObjectDelete`. The controller can work normally, but a later restart of the virtual host controller does not finish.

This follows the work-item reuse mechanism described in [#96](https://github.com/vadimgrn/usbip-win2/issues/96#issuecomment-2519419106) and documents a work-item self-wait that blocks unload in 0.9.8.0. The results below are new measurements of that code and a proposed correction.

The PR changes one source file, with 27 insertions and 7 deletions. It gives each connection phase its own work item, including retries, and preserves the existing cleanup and extended-context lifetime pin.

## Evidence Status

### Confirmed

| Check | Result |
|---|---|
| Original 0.9.8.0 installer/client, independent VIIPER 0.7.0 server, one neutral Xbox 360 attach/detach | Restart before attachment passed. Restart after use exceeded the 300-second harness limit. |
| Pristine release-tag source, compiled locally with the same tools and test certificate as the correction | Restart after use exceeded 300 seconds. |
| Corrected source in the matched comparison | The same restart returned 0 in 138 ms. |
| Corrected source, repeated/error/cancellation cases | 22 targeted kernel checks passed. |
| Native builds | AMD64 and ARM64 passed. |
| Deterministic model using the actual source functions | 129/129 cases passed. The pristine-source control reproduced the self-wait. Removing the context lifetime pin caused 30 failures. |

The matched kernel tests used separate clean Windows 11 Enterprise LTSC Evaluation VMs, each with 4 vCPUs and 4 GiB RAM. Both came from the same 26100.1742 evaluation image and used MSVC 14.51, WDK 10.0.28000.2526, Release/x64 builds, and the same test certificate. `!verifier` in the failing control dump reports flags `0x00000000`. These were not low-resource-injection failures.

Both loaded UDE images were identified through the kernel module list and hashed before testing:

```text
Pristine-source control: B3B1396A5F1D995044B3DC650557A2E71DCBEEB1418786DC7960616BB54F4C4E
Corrected source:        BAB9E332ECA7D187F8B49A0E8E4C6E8705D3FE90D80E3464FA67931F4BF69D1E
```

The table reports one independent VIIPER reproduction with the vendor binary and one paired pristine/corrected-source comparison. The paired VMs ran concurrently. These are controlled examples, not a measured reproduction rate. Additional corrected-driver coverage is listed below.

The control generated an `EXRESOURCE_TIMEOUT_LIVEDUMP` (`0x1cc`) diagnostic dump. It did not blue-screen. The debugger attributes the resource timeout to an owner thread blocked in `usbip2_ude!FxStubDriverUnload`, whose stack enters `Wdf01000!FxDriver::Unload`. A separate work-item callback is waiting during deletion. Its matching PDB resolves that callback to:

```text
Wdf01000!FxWorkItem::WaitForSignal
Wdf01000!FxWorkItem::Dispose
Wdf01000!FxObject::DeleteObject
Wdf01000!imp_WdfObjectDelete
usbip2_ude!`anonymous namespace'::complete+0x311
Wdf01000!FxWorkItem::WorkItemHandler
Wdf01000!FxWorkItem::WorkItemThunk
```

The offset is specific to the locally built pristine control. In the earlier release-binary dump, a typed `FxWorkItem` had running count 1, `m_Enqueued == FALSE`, `m_RunningDown == TRUE`, and `m_WorkItemThread == NULL` while its own callback was executing the delete. Its context type was `workitem_ctx`, and `args.function` pointed to `"connect"`.

### Hypothesized scheduling sequence

The precise instruction interleaving is reconstructed from those fields, the framework source, and the deterministic negative control:

1. Callback A handles address resolution and starts `WskConnect` using the same `WDFWORKITEM`.
2. WSK completes quickly and enqueues that item again before callback A returns.
3. A second thunk starts callback B and records its thread in the item's shared `m_WorkItemThread` field.
4. Callback A returns. Its thunk clears that same field.
5. Callback B completes the attach request, then calls `WdfObjectDelete`.
6. `FlushAndRundown` sees that the stored thread does not equal the caller and waits for the work item to finish. The caller is itself the remaining callback.

The [framework implementation](https://github.com/microsoft/Windows-Driver-Frameworks/blob/b6191d9543441329154da32f7ab9bdd97228dd3c/src/framework/shared/core/fxworkitem.cpp#L353) clears `m_Enqueued` before invoking the callback. [WorkItemThunk](https://github.com/microsoft/Windows-Driver-Frameworks/blob/b6191d9543441329154da32f7ab9bdd97228dd3c/src/framework/shared/core/fxworkitem.cpp#L429) stores and clears the thread field, and [FlushAndRundown](https://github.com/microsoft/Windows-Driver-Frameworks/blob/b6191d9543441329154da32f7ab9bdd97228dd3c/src/framework/shared/core/fxworkitem.cpp#L445) uses it to decide whether to wait. The loaded WDF binary's thunk disassembly was also checked against this store/clear behavior.

### Unverified assumptions and scope

Runtime validation is AMD64 and loopback only. ARM64 was cross-compiled because no ARM64 hardware was available. The builds used test certificates confined to the disposable VMs. A production-signed corrected package and full HIDMaestro integration testing are still pending.

The branch is based on release tag `v.0.9.8.0`, commit `83bd1f781d57ed6efdf15530c55710cf5d4482bc`. The complete patch also applies cleanly to current `develop`, `235dd8d35652be79688bbaaab8dcd0cde39f425d`. That file's intervening changes concern keepalive handling and `offsetof`. The connection/work-item functions are unchanged. The kernel results above are for the release-tag baseline, not a claim that all later upstream changes were tested.

## Proposed correction

Each work item is now enqueued once. A connection attempt gets a fresh item after socket creation succeeds. The request, address list, and extended context move to that successor. The predecessor clears its three ownership fields and deletes its own work item when handing off with `STATUS_PENDING`.

The existing `wdf::ObjectRef ext_ref(ctx.ctx_ext)` in `complete()` remains alive until the predecessor returns. This matters when the successor finishes before the predecessor has unwound.

Error handling follows the existing paths:

- If socket or work-item allocation fails before handoff, the predecessor still owns its allocations. `workitem_cleanup()` closes the socket, and `destroy_device_ctx_ext()` frees it.
- Once WSK owns the completion, `connect()` still returns `STATUS_PENDING` unconditionally, including a synchronous WSK result. The predecessor does not complete the request a second time.
- `on_connect()` retries through the same fresh-item path. `wsk::free(SOCKET*&)` clears the old socket pointer before another attempt.
- The raw `WDFMEMORY`/request/address-list fields are transferred, not reference-counted wrapper assignments. The separate stack `ObjectRef` supplies the temporary lifetime pin.

`workitem_cleanup()` owns allocation cleanup for `ctx_ext` and `addrinfo`. It does not complete or free the request, which is handled by `complete()`. The other copied fields (`vhci`, `args`, and `one_attempt`) carry no separate allocation ownership. Retries reach `STATUS_PENDING` through the new `connect()` handoff. The connected path already requires a non-pending result. After handing off, the predecessor only traces its local status and returns. It does not read `ai` or the moved address list.

<details>
<summary>Complete proposed code change</summary>

```diff
diff --git a/drivers/ude/vhci_ioctl.cpp b/drivers/ude/vhci_ioctl.cpp
index 8a74ec6..0ce6722 100644
--- a/drivers/ude/vhci_ioctl.cpp
+++ b/drivers/ude/vhci_ioctl.cpp
@@ -382,11 +382,15 @@ PAGED auto create_socket(_Inout_ SOCKET* &sock, _In_ const ADDRINFOEXW &ai, _In_
         return st;
 }
 
+_IRQL_requires_same_
+_IRQL_requires_(PASSIVE_LEVEL)
+PAGED NTSTATUS create_workitem(_Out_ WDFWORKITEM &wi, _In_ WDFOBJECT parent);
+
 _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)
 PAGED auto connect(
         _In_ WDFREQUEST request,
-        _In_ WDFWORKITEM wi, _Inout_ workitem_ctx &ctx,
+        _Inout_ workitem_ctx &ctx,
         _Inout_ device_ctx_ext &ext, _In_ const ADDRINFOEXW &ai)
 {
         PAGED_CODE();
@@ -404,7 +408,22 @@ PAGED auto connect(
                 return st;
         }
 
-        set_args(ctx.args, request, __func__, &ai);
+        // WSK can complete before this callback returns. A fresh work item
+        // keeps the callbacks' worker-thread state separate during deletion.
+        WDFWORKITEM wi{};
+        st = create_workitem(wi, ctx.vhci);
+        if (NT_ERROR(st)) {
+                Trace(TRACE_LEVEL_ERROR, "WdfWorkItemCreate %!STATUS!", st);
+                return st;
+        }
+
+        auto &next = *get_workitem_ctx(wi);
+        next = ctx;
+        ctx.ctx_ext = WDF_NO_HANDLE;
+        ctx.addrinfo = nullptr;
+        ctx.request = WDF_NO_HANDLE;
+
+        set_args(next.args, request, __func__, &ai);
 
         auto irp = WdfRequestWdmGetIrp(request);
         IoSetCompletionRoutine(irp, irp_complete, wi, true, true, true);
@@ -419,7 +438,6 @@ _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)
 PAGED auto on_connect(
         _In_ WDFREQUEST request,
-        _In_ WDFWORKITEM wi, 
         _Inout_ workitem_ctx &ctx,
         _Inout_ device_ctx_ext &ext,
         _In_ const ADDRINFOEXW &ai)
@@ -436,7 +454,7 @@ PAGED auto on_connect(
                 free(ext.sock);
 
                 if (st != STATUS_CANCELLED && ai.ai_next) {
-                        st = connect(request, wi, ctx, ext, *ai.ai_next);
+                        st = connect(request, ctx, ext, *ai.ai_next);
                 }
         }
 
@@ -466,13 +484,15 @@ PAGED void NTAPI complete(_In_ WDFWORKITEM wi)
                 st = STATUS_CANCELLED;
                 TraceDbg("req %04x, set %!STATUS!, vhci is being removing", ptr04x(request), st);
         } else if (auto ai = ctx.args.ai) {
-                st = on_connect(request, wi, ctx, ext, *ai);
+                st = on_connect(request, ctx, ext, *ai);
         } else if (NT_SUCCESS(st)) { // on_addrinfo
                 NT_ASSERT(ctx.addrinfo);
-                st = connect(request, wi, ctx, ext, *ctx.addrinfo);
+                st = connect(request, ctx, ext, *ctx.addrinfo);
         }
 
         if (st == STATUS_PENDING) {
+                // The successor owns the request and allocation cleanup.
+                WdfObjectDelete(wi);
                 return;
         }
 
@@ -523,7 +543,7 @@ PAGED void workitem_cleanup(_In_ WDFOBJECT object)
 
 _IRQL_requires_same_
 _IRQL_requires_(PASSIVE_LEVEL)
-PAGED auto create_workitem(_Out_ WDFWORKITEM &wi, _In_ WDFOBJECT parent)
+PAGED NTSTATUS create_workitem(_Out_ WDFWORKITEM &wi, _In_ WDFOBJECT parent)
 {
         PAGED_CODE();
```

</details>

## Reproduce with the upstream client and an independent server

Use a disposable VM with 0.9.8.0 installed. The uncorrected driver can leave its host-controller restart blocked. The test needs no physical USB device and sends no button or axis changes.

Start the published [VIIPER 0.7.0](https://github.com/Alia5/VIIPER/releases/tag/v0.7.0) executable in a separate terminal:

```text
viiper.exe server --usb.addr=127.0.0.1:3241 --api.addr=127.0.0.1:3242 --api.auto-attach-local-client=false --api.auto-attach-windows-native=false --api.device-handler-connect-timeout=10m --update-notify=none
```

VIIPER's [API](https://github.com/Alia5/VIIPER/blob/47a908c7f19fccbb837ed7eb44464e97428c622e/internal/server/api/server.go) accepts a NUL-terminated command and returns a JSON line. This helper sends one command per connection:

```powershell
function Send-ViiperApi([string]$Command) {
    $client = [Net.Sockets.TcpClient]::new('127.0.0.1', 3242)
    try {
        $stream = $client.GetStream()
        $stream.ReadTimeout = 10000
        $stream.WriteTimeout = 10000
        $bytes = [Text.Encoding]::UTF8.GetBytes($Command + [char]0)
        $stream.Write($bytes, 0, $bytes.Length)
        $reader = [IO.StreamReader]::new($stream, [Text.Encoding]::UTF8)
        return ($reader.ReadLine() | ConvertFrom-Json)
    } finally {
        $client.Dispose()
    }
}

$usbip = 'C:\Program Files\USBip\usbip.exe'
$roots = @(Get-CimInstance Win32_PnPEntity -Filter "Service='usbip2_ude'")
if ($roots.Count -ne 1) { throw 'Expected one virtual USB/IP host controller' }
$rootId = $roots[0].DeviceID

# Cold servicing control, before attaching anything.
pnputil.exe /restart-device $rootId
if ($LASTEXITCODE -ne 0) { throw 'Cold restart failed' }

$bus = Send-ViiperApi 'bus/create 1'
if ($bus.busId -ne 1) { throw 'Bus creation failed' }
$device = Send-ViiperApi 'bus/1/add {"type":"xbox360"}'
if (-not $device.devId) { throw 'Device creation failed' }
$busId = "$($device.busId)-$($device.devId)"

$reply = & $usbip --tcp-port 3241 attach --remote 127.0.0.1 `
    --bus-id $busId --once --receive-mode zero-copy --terse
if ($LASTEXITCODE -ne 0) { throw 'Attach failed' }
$port = [int]($reply -join '').Trim()
& $usbip detach --port $port
if ($LASTEXITCODE -ne 0) { throw 'Detach failed' }
& $usbip port
$removed = Send-ViiperApi ("bus/1/remove " + $device.devId)
if ($removed.devId -ne $device.devId) { throw 'Export removal failed' }
```

Verify the imported-device list is empty, stop VIIPER, then run:

```powershell
pnputil.exe /restart-device $rootId
```

The reported 300 seconds is the harness timeout, not a successful restart duration or a returned Win32 error code. The original driver and pristine-source build did not finish. The corrected build returned 0 in 138 ms in the matched comparison.

Earlier same-version rebind and used-legacy upgrade tests returned Win32 error 481, `ERROR_PNP_QUERY_REMOVE_RELATED_DEVICE_TIMEOUT` in `winerror.h`. Those are separate observations from the 300-second harness timeout. No claim is made that this patch has already completed the downstream upgrade validation or repaired an already wedged legacy instance.

VIIPER prints a generated API password at startup. Raw server logs and kernel dumps are kept private. Only test outcome lines are reproduced here.

## Kernel coverage beyond the paired control

| Cases | Coverage and result |
|---|---|
| 1-8 | Eight zero-copy attach/detach/restart cycles passed. |
| 9-16 | Eight low-latency attach/detach/restart cycles passed. |
| 17 | `localhost` address fallback passed. WPP shows `STATUS_CONNECTION_REFUSED`, then a successful connection and plug-in. |
| 18 | Refused loopback connection failed as expected. Empty imports and restart passed. |
| 19 | Rejected bus ID failed as expected. Empty imports and restart passed. |
| 20 | The server received a full 40-byte `OP_REQ_IMPORT`. The client was terminated while awaiting the reply, then the peer closed. Cleanup and restart passed. |
| 21 | Restart with the server stopped passed. |
| 22 | Restart began while an import was pending. It remained pending before peer closure, then the attach returned 1, restart returned 0, and imports were empty. |

The 21-case trace decoded 1,281 events with no lost events, unknowns, or format errors. The separate pending-parent-removal trace decoded 49 events with the same zero counts and showed `D3Final` followed by driver initialization.

<details>
<summary>Selected outcome log</summary>

```text
Original vendor installer and client, independent VIIPER server
[CONTROL] 2026-09-09T18:54:41.5160687Z RESTART_START phase=cold root=ROOT\USB\0000
[CONTROL] 2026-09-09T18:54:41.6755904Z RESTART_EXIT phase=cold exit=0 elapsedMs=155
[CONTROL] 2026-09-09T18:54:41.6755904Z RESTART_START phase=cold-repeat root=ROOT\USB\0000
[CONTROL] 2026-09-09T18:54:41.8221284Z RESTART_EXIT phase=cold-repeat exit=0 elapsedMs=140
[CONTROL] 2026-09-09T18:54:42.1761429Z ATTACH_EXIT=0 busId=1-1 port=1
[CONTROL] 2026-09-09T18:54:42.2843588Z DETACH_EXIT=0 port=1
[CONTROL] 2026-09-09T18:54:42.3918331Z RESTART_START phase=used root=ROOT\USB\0000
[CONTROL] 2026-09-09T18:55:42.3918732Z RESTART_PENDING phase=used elapsedMs=59997 pid=7536
[CONTROL] 2026-09-09T18:56:42.3984944Z RESTART_PENDING phase=used elapsedMs=120003 pid=7536
[CONTROL] 2026-09-09T18:57:42.4004544Z RESTART_PENDING phase=used elapsedMs=180005 pid=7536
[CONTROL] 2026-09-09T18:58:42.3962186Z RESTART_PENDING phase=used elapsedMs=240001 pid=7536
[CONTROL] 2026-09-09T18:59:42.3977901Z RESTART_PENDING phase=used elapsedMs=300002 pid=7536
[CONTROL] 2026-09-09T18:59:42.3991603Z RESTART_TIMEOUT phase=used pid=7536

Pristine source, same compiler and certificate
[MATCHED-CONTROL] 2026-09-09T20:11:39.9173480Z CI_OPTIONS=0x00080207
[MATCHED-CONTROL] 2026-09-09T20:11:53.2856821Z LOADED_UDE_SHA256=B3B1396A5F1D995044B3DC650557A2E71DCBEEB1418786DC7960616BB54F4C4E
[MATCHED-CONTROL] 2026-09-09T20:11:58.0535327Z RESTART_START phase=cold root=ROOT\USB\0000
[MATCHED-CONTROL] 2026-09-09T20:11:58.4102014Z RESTART_EXIT phase=cold exit=0 elapsedMs=354
[MATCHED-CONTROL] 2026-09-09T20:11:58.4112071Z RESTART_START phase=cold-repeat root=ROOT\USB\0000
[MATCHED-CONTROL] 2026-09-09T20:11:58.5476614Z RESTART_EXIT phase=cold-repeat exit=0 elapsedMs=138
[MATCHED-CONTROL] 2026-09-09T20:11:59.1527889Z ATTACH_EXIT=0 busId=1-1 port=1
[MATCHED-CONTROL] 2026-09-09T20:11:59.2219463Z DETACH_EXIT=0 port=1
[MATCHED-CONTROL] 2026-09-09T20:11:59.2785128Z RESTART_START phase=used root=ROOT\USB\0000
[MATCHED-CONTROL] 2026-09-09T20:12:59.2785460Z RESTART_PENDING phase=used elapsedMs=59999 pid=9084
[MATCHED-CONTROL] 2026-09-09T20:13:59.2927880Z RESTART_PENDING phase=used elapsedMs=120013 pid=9084
[MATCHED-CONTROL] 2026-09-09T20:14:59.3003531Z RESTART_PENDING phase=used elapsedMs=180020 pid=9084
[MATCHED-CONTROL] 2026-09-09T20:15:59.3087575Z RESTART_PENDING phase=used elapsedMs=240029 pid=9084
[MATCHED-CONTROL] 2026-09-09T20:16:59.3088063Z RESTART_PENDING phase=used elapsedMs=300029 pid=9084
[MATCHED-CONTROL] 2026-09-09T20:16:59.3088063Z RESTART_TIMEOUT phase=used pid=9084

Corrected source, same compiler and certificate
[MATCHED-FIX] 2026-09-09T20:11:39.9258013Z CI_OPTIONS=0x00080207
[MATCHED-FIX] 2026-09-09T20:11:53.2829521Z LOADED_UDE_SHA256=BAB9E332ECA7D187F8B49A0E8E4C6E8705D3FE90D80E3464FA67931F4BF69D1E
[MATCHED-FIX] 2026-09-09T20:11:58.0464116Z RESTART_START phase=cold root=ROOT\USB\0000
[MATCHED-FIX] 2026-09-09T20:11:58.3983693Z RESTART_EXIT phase=cold exit=0 elapsedMs=349
[MATCHED-FIX] 2026-09-09T20:11:58.3983693Z RESTART_START phase=cold-repeat root=ROOT\USB\0000
[MATCHED-FIX] 2026-09-09T20:11:58.5387841Z RESTART_EXIT phase=cold-repeat exit=0 elapsedMs=138
[MATCHED-FIX] 2026-09-09T20:11:59.1468466Z ATTACH_EXIT=0 busId=1-1 port=1
[MATCHED-FIX] 2026-09-09T20:11:59.2177397Z DETACH_EXIT=0 port=1
[MATCHED-FIX] 2026-09-09T20:11:59.2962917Z RESTART_START phase=used root=ROOT\USB\0000
[MATCHED-FIX] 2026-09-09T20:11:59.4322812Z RESTART_EXIT phase=used exit=0 elapsedMs=138

Corrected source, lifecycle cases
[PATCHED] 2026-09-09T19:52:10.4659390Z RESTART_START phase=zero-copy-1 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:10.6352933Z RESTART_EXIT phase=zero-copy-1 exit=0 elapsedMs=152
[PATCHED] 2026-09-09T19:52:10.6352933Z CASE_PASS=zero-copy-1 count=1
[PATCHED] 2026-09-09T19:52:10.6899336Z RESTART_START phase=zero-copy-2 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:10.8304004Z RESTART_EXIT phase=zero-copy-2 exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:10.8309497Z CASE_PASS=zero-copy-2 count=2
[PATCHED] 2026-09-09T19:52:10.8742997Z RESTART_START phase=zero-copy-3 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:11.0204262Z RESTART_EXIT phase=zero-copy-3 exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:11.0204262Z CASE_PASS=zero-copy-3 count=3
[PATCHED] 2026-09-09T19:52:11.0783419Z RESTART_START phase=zero-copy-4 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:11.2225128Z RESTART_EXIT phase=zero-copy-4 exit=0 elapsedMs=139
[PATCHED] 2026-09-09T19:52:11.2225128Z CASE_PASS=zero-copy-4 count=4
[PATCHED] 2026-09-09T19:52:11.2673506Z RESTART_START phase=zero-copy-5 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:11.4148865Z RESTART_EXIT phase=zero-copy-5 exit=0 elapsedMs=136
[PATCHED] 2026-09-09T19:52:11.4148865Z CASE_PASS=zero-copy-5 count=5
[PATCHED] 2026-09-09T19:52:11.4676280Z RESTART_START phase=zero-copy-6 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:11.6027878Z RESTART_EXIT phase=zero-copy-6 exit=0 elapsedMs=134
[PATCHED] 2026-09-09T19:52:11.6027878Z CASE_PASS=zero-copy-6 count=6
[PATCHED] 2026-09-09T19:52:11.6448341Z RESTART_START phase=zero-copy-7 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:11.7929754Z RESTART_EXIT phase=zero-copy-7 exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:11.7929754Z CASE_PASS=zero-copy-7 count=7
[PATCHED] 2026-09-09T19:52:11.8379144Z RESTART_START phase=zero-copy-8 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:11.9837140Z RESTART_EXIT phase=zero-copy-8 exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:11.9843844Z CASE_PASS=zero-copy-8 count=8
[PATCHED] 2026-09-09T19:52:12.0368923Z RESTART_START phase=low-latency-1 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:12.1828725Z RESTART_EXIT phase=low-latency-1 exit=0 elapsedMs=137
[PATCHED] 2026-09-09T19:52:12.1828725Z CASE_PASS=low-latency-1 count=9
[PATCHED] 2026-09-09T19:52:12.2258963Z RESTART_START phase=low-latency-2 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:12.3723034Z RESTART_EXIT phase=low-latency-2 exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:12.3723034Z CASE_PASS=low-latency-2 count=10
[PATCHED] 2026-09-09T19:52:12.4147560Z RESTART_START phase=low-latency-3 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:12.5623567Z RESTART_EXIT phase=low-latency-3 exit=0 elapsedMs=139
[PATCHED] 2026-09-09T19:52:12.5623567Z CASE_PASS=low-latency-3 count=11
[PATCHED] 2026-09-09T19:52:12.6219025Z RESTART_START phase=low-latency-4 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:12.7573413Z RESTART_EXIT phase=low-latency-4 exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:12.7573413Z CASE_PASS=low-latency-4 count=12
[PATCHED] 2026-09-09T19:52:12.8108652Z RESTART_START phase=low-latency-5 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:12.9461556Z RESTART_EXIT phase=low-latency-5 exit=0 elapsedMs=134
[PATCHED] 2026-09-09T19:52:12.9461556Z CASE_PASS=low-latency-5 count=13
[PATCHED] 2026-09-09T19:52:12.9953708Z RESTART_START phase=low-latency-6 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:13.1372206Z RESTART_EXIT phase=low-latency-6 exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:13.1372206Z CASE_PASS=low-latency-6 count=14
[PATCHED] 2026-09-09T19:52:13.1838920Z RESTART_START phase=low-latency-7 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:13.3278234Z RESTART_EXIT phase=low-latency-7 exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:13.3278234Z CASE_PASS=low-latency-7 count=15
[PATCHED] 2026-09-09T19:52:13.3741095Z RESTART_START phase=low-latency-8 root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:13.5198519Z RESTART_EXIT phase=low-latency-8 exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:13.5203780Z CASE_PASS=low-latency-8 count=16
[PATCHED] 2026-09-09T19:52:15.6767108Z RESTART_START phase=localhost root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:15.8196449Z RESTART_EXIT phase=localhost exit=0 elapsedMs=136
[PATCHED] 2026-09-09T19:52:15.8201587Z CASE_PASS=localhost count=17
[PATCHED] 2026-09-09T19:52:17.8815909Z RESTART_START phase=refused-connect root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:18.0199337Z RESTART_EXIT phase=refused-connect exit=0 elapsedMs=134
[PATCHED] 2026-09-09T19:52:18.0199337Z CASE_PASS=refused-connect count=18
[PATCHED] 2026-09-09T19:52:18.0538336Z RESTART_START phase=rejected-import root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:18.1919906Z RESTART_EXIT phase=rejected-import exit=0 elapsedMs=134
[PATCHED] 2026-09-09T19:52:18.1919906Z CASE_PASS=rejected-import count=19
[PATCHED] 2026-09-09T19:52:18.2469756Z RESTART_START phase=canceled-import root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:18.3822410Z RESTART_EXIT phase=canceled-import exit=0 elapsedMs=134
[PATCHED] 2026-09-09T19:52:18.3822410Z CASE_PASS=canceled-import count=20
[PATCHED] 2026-09-09T19:52:18.4011564Z RESTART_START phase=server-stopped root=ROOT\USB\0000
[PATCHED] 2026-09-09T19:52:18.5371693Z RESTART_EXIT phase=server-stopped exit=0 elapsedMs=135
[PATCHED] 2026-09-09T19:52:18.5371693Z CASE_PASS=server-stopped count=21
[PATCHED] 2026-09-09T19:52:18.6350085Z STRESS_PASS=21

Corrected source, pending parent removal
[PATCHED] 2026-09-09T20:29:08.9479917Z PENDING_IMPORT_CONFIRMED bytes=40
[PATCHED] 2026-09-09T20:29:09.9725274Z PARENT_RESTART_EXITED_BEFORE_PEER_CLOSE=False
[PATCHED] 2026-09-09T20:29:09.9749325Z PENDING_ATTACH_EXIT=1
[PATCHED] 2026-09-09T20:29:10.1633222Z PARENT_RESTART_EXIT=0
[PATCHED] 2026-09-09T20:29:10.3373474Z PENDING_PARENT_REMOVAL_PASS
```

</details>

<details>
<summary>Optional deterministic regression model and extractor</summary>

This is a scheduling/ownership model of the specific interleaving. The real-kernel comparison is reported above. The extractor copies the actual `connect`, `on_connect`, `complete`, and `workitem_cleanup` functions from a selected source tree so the same harness can exercise the pristine source and the correction.

Save the two files below together and run in an x64 Visual Studio developer shell:

```text
python extract.py PATH_TO_SOURCE_ROOT callbacks.inc
cl /nologo /std:c++20 /EHsc /W4 /wd4189 /Fe:model.exe model.cpp
model.exe
```

With pristine tag source, use `model.exe old` for the expected-self-wait control. With corrected source, omit `old` for the 129-case run. The final results were `129/129`, an expected `1/1` negative control, and `99/129` after removing the lifetime pin. The extracted upstream code remains under the project's BSD-2-Clause license.

`extract.py`:

```python
from pathlib import Path
import sys

root = Path(sys.argv[1])
output = Path(sys.argv[2])
source = (root / 'drivers/ude/vhci_ioctl.cpp').read_text(encoding='utf-8-sig')

def function(marker):
    start = source.index(marker)
    brace = source.index('{', start)
    depth = 1
    end = brace + 1
    while depth:
        if source[end] == '{': depth += 1
        elif source[end] == '}': depth -= 1
        end += 1
    return source[start:end]

parts = [function('PAGED auto connect(\n        _In_ WDFREQUEST'),
         function('PAGED auto on_connect('),
         function('PAGED void NTAPI complete('),
         function('PAGED void workitem_cleanup(')]
output.write_text('// Extracted from usbip-win2 vhci_ioctl.cpp, BSD-2-Clause.\n'
                  '// Copyright (c) 2022-2026 Vadym Hrynchyshyn.\n' + '\n\n'.join(parts), encoding='utf-8')
```

`model.cpp`:

```cpp
// Deterministic scheduler for the actual extracted connection callbacks.
// The work-item thread field and completion event follow Microsoft's
// Windows-Driver-Frameworks/src/framework/shared/core/fxworkitem.cpp.
#include <atomic>
#include <chrono>
#include <condition_variable>
#include <exception>
#include <iostream>
#include <memory>
#include <mutex>
#include <stdexcept>
#include <thread>
#include <vector>
#include <algorithm>

#define PAGED
#define NTAPI
#define PAGED_CODE() ((void)0)
#define TraceDbg(...) ((void)0)
#define Trace(...) ((void)0)
#define NT_SUCCESS(x) ((x) >= 0)
#define NT_ERROR(x) ((x) < 0)
#define NT_ASSERT(x) do { if (!(x)) throw std::runtime_error("assertion: " #x); } while(0)
#define NT_VERIFY(x) NT_ASSERT(x)
using NTSTATUS=int;
constexpr int STATUS_PENDING=0x103, STATUS_CANCELLED=-1, FAILURE=-2;
constexpr int AF_INET=2;
constexpr auto WDF_NO_HANDLE=nullptr;
struct SOCKADDR_INET {int si_family=AF_INET; int Ipv4=0, Ipv6=0;};
struct ADDRINFOEXW {SOCKADDR_INET* ai_addr; ADDRINFOEXW* ai_next;};
struct Socket {};
struct Memory; struct Ext { Socket* sock=nullptr; int attr=0; Memory* owner=nullptr; int location_hash() const; };
struct Memory {Ext ext; std::atomic<int> refs{1}; std::atomic<int> deletes{0}; Memory(){ext.owner=this;}}; int Ext::location_hash() const { NT_ASSERT(owner->refs>0); return 1; }
struct Host {bool removing=false;};
struct WorkItem;
struct Irp {WorkItem* next=nullptr;};
struct Request {int status=0; size_t info=8; Irp irp; std::atomic<int> completions{0}; int result=0;};
using WDFWORKITEM=WorkItem*;
using WDFOBJECT=void*;
using WDFMEMORY=Memory*;
using WDFDEVICE=Host*;
using WDFREQUEST=Request*;
struct Args {size_t info=0; const char* function=nullptr; const ADDRINFOEXW* ai=nullptr;};
struct Ctx {Host* vhci; Request* request; Memory* ctx_ext; ADDRINFOEXW* addrinfo; Args args; bool one_attempt=true;};
using workitem_ctx=Ctx;
using device_ctx_ext=Ext;
struct WorkItem {
 Ctx ctx{};
 std::mutex lock;
 std::condition_variable event;
 int running=0, enqueues=0;
 std::thread::id recorded;
 bool deleted=false,enqueued=false;
};
struct Invocation {WorkItem* item; std::mutex lock; std::condition_variable event; bool started=false,finished=false,childFinished=false;};
struct Scenario {
 bool overlap=false, eager=false;
 int failedConnections=0, socketFailure=0, allocationFailure=0, cancelAt=0, removeAt=0;
 bool removing=false;
 std::atomic<int> allocations{0}, sockets{0}, connects{0}, freedAddresses{0}, deadlocks{0}, otherErrors{0};
 std::mutex lock;
 std::vector<std::unique_ptr<WorkItem>> items;
 std::vector<std::thread> threads;
 std::vector<WorkItem*> queued;
 std::vector<std::unique_ptr<Socket>> socketObjects;
 Memory memory;
 Host host;
 Request request;
 Memory* deviceMemory=nullptr;
 std::vector<ADDRINFOEXW> addresses;
 SOCKADDR_INET address{};
} *run;
thread_local std::shared_ptr<Invocation> invocation;

void complete(WorkItem*);
void workitem_cleanup(void*);
Ctx* get_workitem_ctx(WorkItem* wi) {return &wi->ctx;}
Host* get_vhci_ctx(Host* h) {return h;}
Ext& get_device_ctx_ext(Memory* m) {NT_ASSERT(m && m->refs>0); return m->ext;}
bool get_flag(bool v) {return v;}
namespace wdf {
struct ObjectRef {
 Memory* memory;
 explicit ObjectRef(Memory* m):memory(m){NT_ASSERT(m && m->refs>0); ++m->refs;}
 ~ObjectRef(){--memory->refs;}
};
}
void WdfObjectDelete(Memory* m){NT_ASSERT(m->deletes.fetch_add(1)==0); --m->refs;}
void WdfObjectDelete(WorkItem* wi){
 std::unique_lock guard(wi->lock);
 NT_ASSERT(!wi->deleted);
 if((wi->running || wi->enqueued) && wi->recorded!=std::this_thread::get_id()){
  if(!wi->event.wait_for(guard,std::chrono::milliseconds(250),[&]{return wi->running==0 && !wi->enqueued;})){
   ++run->deadlocks;
   throw std::runtime_error("work item waits for its own callback");
  }
 }
 wi->deleted=true;
 guard.unlock();
 workitem_cleanup(wi);
}
void thunk(WorkItem* wi, std::shared_ptr<Invocation> parent){
 auto current=std::make_shared<Invocation>();current->item=wi;invocation=current;
 {std::lock_guard guard(wi->lock);wi->recorded=std::this_thread::get_id();wi->enqueued=false;++wi->running;}
 if(parent){
  {std::lock_guard guard(parent->lock);parent->started=true;}parent->event.notify_all();
  if(!run->eager){std::unique_lock guard(parent->lock);parent->event.wait(guard,[&]{return parent->finished;});}
 }
 try{complete(wi);}catch(const std::exception& e){
  if(std::string(e.what())!="work item waits for its own callback"){++run->otherErrors;std::cerr<<e.what()<<'\n';}
 }
 {std::lock_guard guard(wi->lock);--wi->running;wi->recorded={};}wi->event.notify_all();
 {std::lock_guard guard(current->lock);current->finished=true;}current->event.notify_all();
 if(parent && run->eager){{std::lock_guard guard(parent->lock);parent->childFinished=true;}parent->event.notify_all();}
 invocation.reset();
}
void WdfWorkItemEnqueue(WorkItem* wi){
 {std::lock_guard guard(wi->lock);NT_ASSERT(!wi->deleted);if(wi->enqueued)return;wi->enqueued=true;++wi->enqueues;}
 if(run->overlap){
  auto parent=invocation;
  std::lock_guard guard(run->lock);
  run->threads.emplace_back([wi,parent]{thunk(wi,parent);});
 } else run->queued.push_back(wi);
}
int create_workitem(WorkItem*& wi,void*){
 int n=++run->allocations;
 if(n==run->allocationFailure)return FAILURE;
 auto item=std::make_unique<WorkItem>();wi=item.get();
 std::lock_guard guard(run->lock);run->items.push_back(std::move(item));return 0;
}
int create_socket(Socket*& socket,const ADDRINFOEXW&,Ext*){
 if(++run->sockets==run->socketFailure)return FAILURE;
 auto object=std::make_unique<Socket>();socket=object.get();
 std::lock_guard guard(run->lock);run->socketObjects.push_back(std::move(object));return 0;
}
int close(Socket*){return 0;}
void free(Socket*& s){s=nullptr;}
bool close_socket(Socket*){return true;}
namespace wsk {void free(ADDRINFOEXW* a){if(a)++run->freedAddresses;}}
int WdfRequestGetStatus(Request* r){NT_ASSERT(r->completions==0);return r->status;}
size_t WdfRequestGetInformation(Request* r){NT_ASSERT(r->completions==0);return r->info;}
void WdfRequestSetInformation(Request* r,size_t n){NT_ASSERT(r->completions==0);r->info=n;}
void WdfRequestComplete(Request* r,int st){NT_ASSERT(r->completions==0);r->result=st;++r->completions;if(run->deviceMemory){WdfObjectDelete(run->deviceMemory);run->deviceMemory=nullptr;}}
Irp* WdfRequestWdmGetIrp(Request* r){NT_ASSERT(r->completions==0);return &r->irp;}
void set_args(Args& a,Request* r,const char* name,const ADDRINFOEXW* ai=nullptr){a.info=r->info;a.function=name;a.ai=ai;}
void irp_complete(){}
void IoSetCompletionRoutine(Irp* irp,void(*)(),WorkItem* wi,bool,bool,bool){irp->next=wi;}
int connect(Socket*,SOCKADDR_INET*,Irp* irp){
 int hop=++run->connects;run->request.status=hop==run->cancelAt?STATUS_CANCELLED:((hop<=run->failedConnections)?FAILURE:0);if(hop==run->removeAt)run->host.removing=true;
 auto parent=invocation;
 WdfWorkItemEnqueue(irp->next);
 if(run->overlap){std::unique_lock guard(parent->lock);parent->event.wait(guard,[&]{return run->eager?parent->childFinished:parent->started;});}
 return STATUS_PENDING;
}
int connected(Request*,Ctx& ctx,Ext&){run->deviceMemory=ctx.ctx_ext;ctx.ctx_ext=nullptr;return 0;}
void stop_attach_attempts(Host&,int){}
bool can_reattach(Host*,int,int){return false;}
void start_attach_attempts(Host*,Host&,int,bool){}
namespace vhci {enum class state{disconnected};}
void device_state_changed(Host*,int,int,vhci::state){}

#include "callbacks.inc"

bool scenario(bool old,bool overlap,int addresses,int failConnections,int socketFailure,int allocFailure,bool removing,bool eager=false,bool once=true,int cancelAt=0,int removeAt=0){
 Scenario s;run=&s;s.overlap=overlap;s.eager=eager;s.failedConnections=failConnections;s.socketFailure=socketFailure;s.allocationFailure=allocFailure;s.host.removing=removing;s.cancelAt=cancelAt;s.removeAt=removeAt;
 s.addresses.resize(addresses);
 for(int i=0;i<addresses;++i)s.addresses[i]={&s.address,i+1<addresses?&s.addresses[i+1]:nullptr};
 WorkItem* initial=nullptr;
 if(create_workitem(initial,&s.host)!=0)return false;
 initial->ctx={&s.host,&s.request,&s.memory,s.addresses.data(),{8,"lookup",nullptr},once};
 WdfWorkItemEnqueue(initial);
 if(overlap){
  for(size_t i=0;;++i){
   std::thread thread;
   {std::lock_guard guard(s.lock);if(i>=s.threads.size())break;thread=std::move(s.threads[i]);}
   thread.join();
  }
 } else {
  for(size_t i=0;i<s.queued.size();++i)thunk(s.queued[i],nullptr);
 }
 if(s.deviceMemory)WdfObjectDelete(s.deviceMemory);
 if(old && overlap)return s.deadlocks==1 && s.request.completions==1 && s.otherErrors==0;
 bool expectedSuccess=!removing && !socketFailure && !allocFailure && !cancelAt && !removeAt && failConnections<addresses;
 bool ok=s.deadlocks==0 && s.otherErrors==0 && s.request.completions==1 && (s.request.result==0)==expectedSuccess && s.freedAddresses==1 && s.memory.deletes==1 && s.memory.refs==0;
 for(auto& item:s.items)ok=ok && item->deleted && item->running==0 && (old || item->enqueues==1);
 return ok;
}
int main(int argc,char** argv){
 bool old=argc>1 && std::string(argv[1])=="old";int failures=0,total=0;
 auto check=[&](bool overlap,int n,int failuresToConnect,int socketFailure,int allocFailure,bool removing,bool eager=false,bool once=true,int cancelAt=0,int removeAt=0){
  ++total;bool pass=scenario(old,overlap,n,failuresToConnect,socketFailure,allocFailure,removing,eager,once,cancelAt,removeAt);
  if(!pass)++failures;
  std::cout<<(pass?"PASS":"FAIL")<<" overlap="<<overlap<<" eager="<<eager<<" once="<<once<<" cancelAt="<<cancelAt<<" removeAt="<<removeAt<<" addresses="<<n<<" failedConnects="<<failuresToConnect<<" socketFailure="<<socketFailure<<" allocationFailure="<<allocFailure<<" removing="<<removing<<'\n';
 };
 if(old)check(true,1,0,0,0,false);
 if(!old){
  for(bool once:{true,false})for(int mode=0;mode<3;++mode)for(int n=1;n<=4;++n)for(int bad=0;bad<=n;++bad)check(mode!=0,n,bad,0,0,false,mode==2,once);
  for(int n=1;n<=4;++n)for(int hop=1;hop<=n;++hop){check(false,n,n,hop,0,false);check(false,n,n,0,hop+1,false);}
  check(false,1,0,0,0,true); for(int mode=0;mode<3;++mode)for(int hop=1;hop<=4;++hop){check(mode!=0,4,4,0,0,false,mode==2,false,hop,0);check(mode!=0,4,4,0,0,false,mode==2,false,0,hop);}
 }
 std::cout<<total-failures<<'/'<<total<<" scheduler/ownership scenarios passed\n";return failures?1:0;
}
```

</details>

The test-signed binaries are not proposed as a deployment package. If this correction is suitable, a Microsoft-signed AMD64/ARM64 build would allow the remaining HIDMaestro consumer integration checks to run against the intended package. Candidate packages can be checked against the same reproduction and downstream battery.
